### PR TITLE
fix: op runのときLinux版opにフォールバックする処理を追加

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -60,6 +60,29 @@
     JQ_COLORS = "1;36:0;33:0;33:0;36:0;32:1;39:1;39";
   };
 
+  home.file.".local/bin/op" = lib.mkIf pkgs.stdenv.isLinux {
+    executable = true;
+    text = ''
+      #!/bin/bash
+      OP_EXE="/mnt/c/Users/${config.home.username}/AppData/Local/Microsoft/WinGet/Links/op.exe"
+      OP_LINUX="/usr/bin/op"
+
+      # op run は Linux のバイナリを実行するため、Windows の op.exe では動作しない
+      if [ "$1" = "run" ] && [ -x "$OP_LINUX" ]; then
+        exec "$OP_LINUX" "$@"
+      fi
+
+      if [ ! -f "$OP_EXE" ]; then
+        echo "[ERROR] op.exe not found at $OP_EXE" >&2
+        exit 1
+      fi
+
+      OP_VARS=$(env | grep ^OP_ | cut -d= -f1 | tr '\n' ':')
+      export WSLENV="''${WSLENV:-}:''${OP_VARS%:}"
+      exec "$OP_EXE" "$@"
+    '';
+  };
+
   home.file.".signature".text = ''
     Kentaro Ohkouchi
   '';


### PR DESCRIPTION
## Summary

- `op run` サブコマンドは引数で指定したコマンドをサブプロセスとして実行するが、Windows の `op.exe` 経由では WSL2 の Linux バイナリが `%PATH%` で検索され見つからない
- `op run` を検出した場合に Linux 版 `/usr/bin/op` にフォールバックする処理をラッパースクリプトに追加

## Test plan

- [x] `op whoami` が Windows Hello 認証で動作することを確認
- [x] `op run --env-file=.env -- <linux-command>` が Linux 版 op 経由で動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Linux環境でのop コマンド実行に対応しました。
  * WSL（Windows Subsystem for Linux）環境でLinux版が利用できない場合、Windows版のop.exeに自動でフォールバックします。
  * WSL環境でop関連の環境変数を自動的に設定し、ツール間の連携を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->