### PR TITLE
feat: Emacs起動時にIBusを無効化するdesktopエントリを追加

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -86,4 +86,59 @@
   home.file.".signature".text = ''
     Kentaro Ohkouchi
   '';
+
+  xdg.desktopEntries = lib.mkIf pkgs.stdenv.isLinux {
+    emacs = {
+      name = "Emacs (GUI)";
+      genericName = "Text Editor";
+      comment = "GNU Emacs is an extensible, customizable text editor - and more";
+      mimeType = [
+        "text/english" "text/plain" "text/x-makefile" "text/x-c++hdr"
+        "text/x-c++src" "text/x-chdr" "text/x-csrc" "text/x-java"
+        "text/x-moc" "text/x-pascal" "text/x-tcl" "text/x-tex"
+        "application/x-shellscript" "text/x-c" "text/x-c++"
+      ];
+      exec = "env GTK_IM_MODULE=none XMODIFIERS=@im=none /usr/bin/emacs %F";
+      icon = "emacs";
+      terminal = false;
+      categories = [ "Utility" "Development" "TextEditor" ];
+      startupNotify = true;
+      settings = {
+        StartupWMClass = "Emacs";
+        Keywords = "Text;Editor;";
+        TryExec = "/usr/bin/emacs";
+      };
+    };
+    emacsclient = {
+      name = "Emacs (Client)";
+      genericName = "Text Editor";
+      comment = "Edit text";
+      mimeType = [
+        "text/english" "text/plain" "text/x-makefile" "text/x-c++hdr"
+        "text/x-c++src" "text/x-chdr" "text/x-csrc" "text/x-java"
+        "text/x-moc" "text/x-pascal" "text/x-tcl" "text/x-tex"
+        "application/x-shellscript" "text/x-c" "text/x-c++"
+        "x-scheme-handler/org-protocol"
+      ];
+      exec = ''env GTK_IM_MODULE=none XMODIFIERS=@im=none sh -c "if [ -n \"$*\" ]; then exec /usr/bin/emacsclient --alternate-editor= --reuse-frame \"$@\"; else exec emacsclient --alternate-editor= --create-frame; fi" sh %F'';
+      icon = "emacs";
+      terminal = false;
+      categories = [ "Development" "TextEditor" ];
+      startupNotify = true;
+      settings = {
+        StartupWMClass = "Emacs";
+        Keywords = "emacsclient;";
+      };
+      actions = {
+        new-window = {
+          name = "New Window";
+          exec = "env GTK_IM_MODULE=none XMODIFIERS=@im=none /usr/bin/emacsclient --alternate-editor= --create-frame %F";
+        };
+        new-instance = {
+          name = "New Instance";
+          exec = "env GTK_IM_MODULE=none XMODIFIERS=@im=none emacs %F";
+        };
+      };
+    };
+  };
 }


### PR DESCRIPTION
## Summary
- Emacs内ではSKK(ddskk)で日本語入力するため、デスクトップランチャーからの起動時にシステムのIBus(ibus-skk)を無効化する `.desktop` エントリを `xdg.desktopEntries` で追加
- `GTK_IM_MODULE=none` および `XMODIFIERS=@im=none` を `Exec` 行に設定
- `emacs` と `emacsclient` の両方に対応
- Linux環境でのみ有効 (`lib.mkIf pkgs.stdenv.isLinux`)

## TODO
- [ ] `home-manager switch` 適用後、手動で作成した `~/.local/share/applications/emacs.desktop` および `emacsclient.desktop` を削除する

## Test plan
- [ ] `home-manager switch` を実行し、`.desktop` ファイルが生成されることを確認
- [ ] デスクトップランチャーからEmacsを起動し、IBusが無効化されていることを確認
- [ ] Emacs内のSKK(ddskk)で日本語入力が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Emacsのデスクトップ統合が拡張されました。GUIバージョンとクライアントバージョンの2つのデスクトップエントリを追加し、システムアプリケーションメニューからの起動やファイルの関連付けが改善されます。Emacsクライアントには新規ウィンドウ作成などのアクションも含まれます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->