### PR TITLE
feat: Ubuntuホスト追加とOneDrive設定管理

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       homeConfigurations = {
         "nanasess@wsl-gentoo" = home-manager.lib.homeManagerConfiguration {
           pkgs = nixpkgs.legacyPackages.x86_64-linux;
-          modules = [ ./home.nix ./hosts/wsl-gentoo.nix ];
+          modules = [ ./home.nix ./hosts/wsl-gentoo.nix ./modules/onedrive.nix ];
         };
         "nanasess@macbook" = home-manager.lib.homeManagerConfiguration {
           pkgs = nixpkgs.legacyPackages.x86_64-darwin;
@@ -26,7 +26,7 @@
         };
         "nanasess@ubuntu" = home-manager.lib.homeManagerConfiguration {
           pkgs = nixpkgs.legacyPackages.x86_64-linux;
-          modules = [ ./home.nix ./hosts/ubuntu.nix ];
+          modules = [ ./home.nix ./hosts/ubuntu.nix ./modules/onedrive.nix ];
         };
       };
 

--- a/hosts/ubuntu.nix
+++ b/hosts/ubuntu.nix
@@ -4,6 +4,7 @@
   home.homeDirectory = "/home/nanasess";
 
   home.packages = with pkgs; [
+    onedrive
     walker
     libqalculate
   ];
@@ -26,6 +27,22 @@
       ${pkgs.dconf}/bin/dconf write "$profile_path/audible-bell" false
     fi
   '';
+
+  systemd.user.services.onedrive = {
+    Unit = {
+      Description = "OneDrive Free Client";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+    };
+    Service = {
+      ExecStart = "${pkgs.onedrive}/bin/onedrive --monitor";
+      Restart = "on-failure";
+      RestartSec = 3;
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
 
   dconf.settings = {
     "org/gnome/settings-daemon/plugins/media-keys" = {

--- a/modules/onedrive.nix
+++ b/modules/onedrive.nix
@@ -1,0 +1,11 @@
+{ ... }:
+
+{
+  xdg.configFile."onedrive/config".text = ''
+    sync_dir = "~/OneDrive - Skirnir Inc"
+  '';
+
+  xdg.configFile."onedrive/sync_list".text = ''
+    emacs
+  '';
+}


### PR DESCRIPTION
## Summary
- Ubuntuホスト(`nanasess@ubuntu`)をhome-manager設定に追加
- OneDrive設定ファイル(`config`, `sync_list`)を共通モジュール(`modules/onedrive.nix`)で管理（Ubuntu, wsl-gentoo共通）
- Ubuntu向けにNix版onedriveパッケージとsystemdユーザーサービス（`--monitor`モード）を追加
- Walker、Emacs wrapper、zoxide等の既存改善を含む

## Test plan
- [ ] `nix build '.#homeConfigurations."nanasess@ubuntu".activationPackage'` が成功すること
- [ ] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` が成功すること
- [ ] `nix build '.#homeConfigurations."nanasess@macbook".activationPackage'` が成功すること
- [ ] `home-manager switch` 後に `~/.config/onedrive/config` と `sync_list` がsymlinkになること
- [ ] `systemctl --user status onedrive` でサービスが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * OneDriveの統合サポートを追加しました。
  * OneDriveのバックグラウンド自動同期機能が利用可能になりました。
  * ユーザーの環境で指定されたディレクトリとファイルが自動的に同期されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->