### PR TITLE
feat: terraform と azure-cli を共通パッケージに追加

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -4,6 +4,11 @@
   home.username = "nanasess";
   home.stateVersion = "24.05";
 
+  nixpkgs.config.allowUnfreePredicate = pkg:
+    builtins.elem (lib.getName pkg) [
+      "terraform"
+    ];
+
   programs.home-manager.enable = true;
 
   home.packages = with pkgs; [


### PR DESCRIPTION
## Summary
- 開発ツールとして `terraform` と `azure-cli` を `home.nix` の共通パッケージに追加
- Nix で管理することで WSL Gentoo / macOS 両環境で同一バージョンを利用可能に

## Test plan
- [ ] `nix flake check` が通ること
- [ ] `home-manager switch` で terraform / az コマンドが利用可能になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 開発環境に Terraform と Azure CLI を追加しました。これによりローカルでのインフラ構築や Azure 操作が容易になります。
  * Terraform のインストールを許可する設定を追加しました（unfree パッケージの許可）。結果として Terraform の利用がシームレスになります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->