### PR TITLE
fix: wsl-gentoo から Ghostty 設定を削除

### DIFF
--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -3,15 +3,6 @@
 {
   home.homeDirectory = "/home/nanasess";
 
-  programs.ghostty = {
-    enable = true;
-    settings = {
-      font-family = "Ubuntu Sans Mono";
-      font-size = 13;
-      theme = "iTerm2 Solarized Light";
-    };
-  };
-
   home.sessionVariables = {
     BROWSER = "wslview";
   };


### PR DESCRIPTION
## Summary
- WSLg 環境での EGL/OpenGL 不整合および日本語 IME 入力非対応のため、wsl-gentoo から Ghostty 設定を削除

## 背景
- nixGL ラッピングで OpenGL エラーは回避できたが、WSLg の Weston が Wayland text-input プロトコル未対応のため日本語入力ができない
- GDK_BACKEND=x11 での XWayland 経由も GTK4 の on-screen keyboard 問題で動作せず
- ubuntu ホストの Ghostty 設定には影響なし

## Test plan
- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` が成功すること
- [x] `nix build '.#homeConfigurations."nanasess@macbook".activationPackage'` が成功すること
- [x] CI が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Ghosttyターミナルエミュレータの設定を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->