### PR TITLE
feat: wsl-gentoo に Ghostty + fcitx5-skk 日本語入力環境を追加

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770318660,
-        "narHash": "sha256-yFVde8QZK7Dc0Xa8eQDsmxLX4NJNfL1NKfctSyiQgMY=",
+        "lastModified": 1773962693,
+        "narHash": "sha256-nf9pgktDE4E2TCavUT1vh3Nd/tfKixL1BK6P32Zp3hI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "471e6a065f9efed51488d7c51a9abbd387df91b8",
+        "rev": "9d3c1d636e7b8ab10f357cd9bee653cd400437de",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770197578,
-        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,14 @@
       homeConfigurations = {
         "nanasess@wsl-gentoo" = home-manager.lib.homeManagerConfiguration {
           pkgs = nixpkgs.legacyPackages.x86_64-linux;
-          modules = [ ./home.nix ./hosts/wsl-gentoo.nix ./modules/onedrive.nix ];
+          modules = [
+            ./home.nix
+            ./hosts/wsl-gentoo.nix
+            ./modules/onedrive.nix
+            {
+              nixGL.packages = nixgl.packages;
+            }
+          ];
         };
         "nanasess@macbook" = home-manager.lib.homeManagerConfiguration {
           pkgs = nixpkgs.legacyPackages.x86_64-darwin;

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -5,7 +5,45 @@
 
   home.sessionVariables = {
     BROWSER = "wslview";
+    GTK_IM_MODULE = "fcitx";
+    XMODIFIERS = "@im=fcitx";
   };
+
+  programs.ghostty = {
+    enable = true;
+    package = config.lib.nixGL.wrap pkgs.ghostty;
+    settings = {
+      font-family = "Ubuntu Sans Mono";
+      font-size = 13;
+      theme = "iTerm2 Solarized Light";
+      scrollbar = "system";
+    };
+  };
+
+  i18n.inputMethod = {
+    enable = true;
+    type = "fcitx5";
+    fcitx5.addons = with pkgs; [
+      fcitx5-skk
+      fcitx5-gtk
+    ];
+  };
+
+  # OneDrive の SKK 辞書へスペースなしのシンボリックリンクを作成
+  home.file.".local/share/skk/SKK-JISYO.ALL".source =
+    config.lib.file.mkOutOfStoreSymlink
+      "${config.home.homeDirectory}/OneDrive - Skirnir Inc/emacs/ddskk/SKK-JISYO.ALL";
+
+  # fcitx5-skk の辞書設定（ユーザー辞書 + OneDrive の SKK-JISYO.ALL）
+  xdg.dataFile."fcitx5/skk/dictionary_list".text = ''
+    type=file,file=$FCITX_CONFIG_DIR/skk/user.dict,mode=readwrite
+    type=file,file=${config.home.homeDirectory}/.local/share/skk/SKK-JISYO.ALL,mode=readonly
+  '';
+
+  # fcitx5-gtk の GTK4 IM モジュールを GTK が見つけられるようにする
+  home.sessionVariablesExtra = ''
+    export GTK_PATH="${config.i18n.inputMethod.package}/lib/gtk-4.0''${GTK_PATH:+:$GTK_PATH}"
+  '';
 
   home.file.".local/bin/op" = {
     executable = true;


### PR DESCRIPTION
## Summary

- wsl-gentoo に Ghostty ターミナルエミュレータを再追加（nixGL wrap 付き）
- fcitx5 + fcitx5-skk による SKK 日本語入力を設定
- GTK4 IM モジュールパス（`GTK_PATH`）の設定で `No IM module matching GTK_IM_MODULE=fcitx found` エラーを解決
- OneDrive の `SKK-JISYO.ALL` 辞書をシンボリックリンク経由で参照（パス中のスペース回避）
- flake.lock を更新（Ghostty 1.2.3 → 1.3.1、nixpkgs 2026-03-18）

## 背景

PR #14 で Ghostty を追加したが、WSLg 環境で日本語 IME が動作せず PR #15 で削除していた。今回 fcitx5-skk + GTK_PATH 設定により日本語入力の問題を解決した。

## 設定ポイント

- `GTK_IM_MODULE=fcitx` + `XMODIFIERS=@im=fcitx` で fcitx5 を有効化
- `GTK_PATH` に fcitx5-with-addons の GTK4 IM モジュールパスを追加（Nix 環境では GTK4 がモジュールを見つけられないため）
- OneDrive の SKK 辞書は libskk が要求する `coding: euc-jp` ヘッダーを先頭に追加する必要あり

## Test plan

- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` が成功すること
- [x] `home-manager switch` 後、Ghostty が起動すること
- [x] Ghostty 内で `Ctrl+Space` → fcitx5-skk で日本語入力できること
- [x] スクロールバーが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Ghosttyターミナルアプリケーションのサポートを追加
  * FCITX5入力メソッドおよびSKK日本語辞書機能を導入
  * GTK4アプリケーションでの入力メソッド互換性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->