### PR TITLE
feat: Ghostty の .desktop ファイルを追加

### DIFF
--- a/hosts/ubuntu.nix
+++ b/hosts/ubuntu.nix
@@ -13,6 +13,21 @@
     };
   };
 
+  home.file.".local/share/applications/com.mitchellh.ghostty.desktop".text = ''
+    [Desktop Entry]
+    Version=1.0
+    Name=Ghostty
+    Type=Application
+    Comment=A terminal emulator
+    Exec=${config.home.homeDirectory}/.nix-profile/bin/ghostty --gtk-single-instance=true
+    Icon=com.mitchellh.ghostty
+    Categories=System;TerminalEmulator;
+    Keywords=terminal;tty;pty;
+    StartupNotify=true
+    StartupWMClass=com.mitchellh.ghostty
+    Terminal=false
+  '';
+
   home.packages = with pkgs; [
     onedrive
     walker


### PR DESCRIPTION
## Summary
- Nix でインストールした Ghostty が GNOME アプリランチャーに表示されない問題を修正
- `~/.local/share/applications/` に `.desktop` ファイルを `home.file` で配置
- `~/.nix-profile/bin/ghostty` を Exec パスに使用し、nixGL ラッピングも正しく動作

## Test plan
- [x] `nix build` でビルドが成功すること
- [x] `home-manager switch` 後に GNOME アプリランチャーに Ghostty が表示されること
- [x] ランチャーから Ghostty が正常に起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Ghosttyのアプリケーションランチャー統合を追加しました。デスクトップメニューからGhosttyを直接起動できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->