### PR TITLE
feat: WezTerm のフォントサイズと画面サイズを拡大

### DIFF
--- a/modules/wezterm/wezterm.lua
+++ b/modules/wezterm/wezterm.lua
@@ -13,6 +13,7 @@ config.default_domain = "WSL:Gentoo-systemd"
 
 config.color_scheme = "Builtin Solarized Light"
 config.font = wezterm.font 'UDEV Gothic NF'
+config.font_size = 14.0
 
 local spawn_tab_in_home = wezterm.action.SpawnCommandInNewTab {
   cwd = '\\\\wsl.localhost\\Gentoo-systemd\\home\\nanasess',
@@ -25,8 +26,8 @@ config.keys = {
   { key = 't', mods = 'SUPER', action = spawn_tab_in_home },
 }
 
-config.initial_cols = 128
-config.initial_rows = 30
+config.initial_cols = 160
+config.initial_rows = 40
 config.enable_scroll_bar = true
 config.show_close_tab_button_in_tabs = false
 


### PR DESCRIPTION
## Summary
- `font_size` を 14.0 に設定し、文字の視認性を改善
- `initial_cols` を 128 → 160、`initial_rows` を 30 → 40 に変更し、作業領域を拡大

## Test plan
- [ ] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` でビルド確認
- [ ] `home-manager switch` 後、WezTerm の新規ウィンドウでフォントサイズと画面サイズが反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定の変更**
  * デフォルトフォントサイズを14.0に設定しました
  * ターミナルウィンドウの初期サイズを拡大しました（幅: 160文字、高さ: 40行）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->