### PR TITLE
feat: WezTerm のカラーテーマを Solarized Light (Gogh) に変更

### DIFF
--- a/modules/wezterm/wezterm.lua
+++ b/modules/wezterm/wezterm.lua
@@ -11,7 +11,7 @@ config.wsl_domains = {
 }
 config.default_domain = "WSL:Gentoo-systemd"
 
-config.color_scheme = "Solarized (light) (terminal.sexy)"
+config.color_scheme = "Solarized Light (Gogh)"
 config.font = wezterm.font 'UDEV Gothic NF'
 config.font_size = 14.0
 


### PR DESCRIPTION
## Summary
- WezTerm のカラーテーマを `Solarized (light) (terminal.sexy)` から `Solarized Light (Gogh)` に変更
- グリーン背景と薄いグレー文字のコントラストが改善され、視認性が向上

## Test plan
- [x] `nix build` でビルド成功を確認
- [x] `home-manager switch` で適用し、WezTerm の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル
* WezTermの配色スキームを更新し、ターミナルの表示体験を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->