### PR TITLE
feat: Ghostty テーマを Solarized Dark Patched に変更

### DIFF
--- a/hosts/ubuntu.nix
+++ b/hosts/ubuntu.nix
@@ -9,7 +9,7 @@
     settings = {
       font-family = "Ubuntu Sans Mono";
       font-size = 13;
-      theme = "iTerm2 Solarized Light";
+      theme = "Solarized Dark Patched";
     };
   };
 


### PR DESCRIPTION
## Summary
- Ghostty のテーマを `iTerm2 Solarized Light` から `Solarized Dark Patched` に変更
- Claude Code の Dark Mode 表示に合わせるための変更

## Test plan
- [x] `nix build '.#homeConfigurations."nanasess@ubuntu".activationPackage'` でビルド確認
- [x] `home-manager switch` 後に Ghostty のテーマが Solarized Dark Patched になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)