### PR TITLE
feat(mise): Node.js バージョン管理を n から mise に移行

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -64,6 +64,15 @@
     enable = true;
   };
 
+  programs.mise = {
+    enable = true;
+    globalConfig = {
+      tools = {
+        node = "lts";
+      };
+    };
+  };
+
   home.sessionVariables = {
     LANG = "ja_JP.UTF-8";
     SSH_AUTH_SOCK = "$HOME/.1password/agent.sock";


### PR DESCRIPTION
## Summary
- `programs.mise` を `home.nix` に追加し、全ホストで mise を有効化
- グローバル設定で Node.js LTS をデフォルトツールとして設定
- `n` (Node.js version manager) からの移行

## Changes
- `home.nix`: `programs.mise` ブロックを追加（`enable = true`, `globalConfig.tools.node = "lts"`）

## Test plan
- [ ] `nix flake check` が成功すること
- [ ] 各ホストの `activationPackage` ビルドが成功すること
- [ ] `home-manager switch` 後に `mise --version` が実行可能なこと
- [ ] `mise install` で Node.js LTS がインストールされること
- [ ] `.zshrc` に `eval "$(mise activate zsh)"` を追加後、`node --version` が動作すること

## Notes
- シェル統合は `programs.zsh.enable` が未設定のため自動有効化されません。`.zshrc` に手動で `eval "$(mise activate zsh)"` の追加が必要です
- `n` はシステムレベル (`/usr/bin/n`) のため、別途アンインストールが必要です

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * mise ツールマネージャーをシステム設定に統合し、有効化しました。
  * Node.js 環境をグローバル設定で LTS (長期サポート) バージョンに設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->