### PR TITLE
feat(emacs): Ubuntu に Emacs 30.2 を Nix 経由で追加

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -93,7 +93,7 @@
       export PATH="${config.home.homeDirectory}/.nix-profile/bin:/nix/var/nix/profiles/default/bin:$PATH"
       export GTK_IM_MODULE=none
       export XMODIFIERS=@im=none
-      exec /usr/bin/emacs "$@"
+      exec emacs "$@"
     '';
   };
 
@@ -105,9 +105,9 @@
       export GTK_IM_MODULE=none
       export XMODIFIERS=@im=none
       if [ -n "$*" ]; then
-        exec /usr/bin/emacsclient --alternate-editor= --reuse-frame "$@"
+        exec emacsclient --alternate-editor= --reuse-frame "$@"
       else
-        exec /usr/bin/emacsclient --alternate-editor= --create-frame
+        exec emacsclient --alternate-editor= --create-frame
       fi
     '';
   };
@@ -127,7 +127,7 @@
       StartupNotify=true
       StartupWMClass=Emacs
       Keywords=Text;Editor;
-      TryExec=/usr/bin/emacs
+      TryExec=${config.home.homeDirectory}/.nix-profile/bin/emacs
     '';
   };
 

--- a/hosts/ubuntu.nix
+++ b/hosts/ubuntu.nix
@@ -33,6 +33,7 @@
   '';
 
   home.packages = with pkgs; [
+    emacs30
     onedrive
     walker
     libqalculate


### PR DESCRIPTION
## Summary
- Ubuntu ホストに Nix の `emacs30` パッケージ (Emacs 30.2) を追加
- Emacs ラッパースクリプトを `/usr/bin/emacs` から Nix 管理の Emacs を参照するように変更

## Changes
- `hosts/ubuntu.nix`: `emacs30` パッケージを追加
- `home.nix`: `emacs-wrapper` と `emacsclient-wrapper` のパスを Nix プロファイル上の実行ファイルに変更
- `home.nix`: `emacs.desktop` の `TryExec` を `~/.nix-profile/bin/emacs` に更新

## Test plan
- [ ] `nix build '.#homeConfigurations."nanasess@ubuntu".activationPackage'` が成功すること
- [ ] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` が成功すること
- [ ] `home-manager switch` 後に `emacs --version` で 30.2 が表示されること
- [ ] emacs-wrapper 経由で Emacs が起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Emacs および Emacsclient の起動パスを Nix プロファイルから取得するように更新しました
  * Ubuntu ホスト設定に Emacs 30 パッケージを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->