### PR TITLE
feat(fonts): udev-gothic-nf フォントパッケージを追加

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -32,6 +32,7 @@
     # Fonts
     noto-fonts
     noto-fonts-color-emoji
+    udev-gothic-nf
   ]
   ++ lib.optionals stdenv.isLinux [
     wakatime-cli


### PR DESCRIPTION
## Summary
- Emacs/WezTerm で使用する UDEV Gothic NF フォントを Nix パッケージとして追加
- `home.nix` の共通パッケージに `udev-gothic-nf` を追加し、全環境（WSL Gentoo / macOS / CI）で利用可能に

## Changes
- `home.nix`: Fonts セクションに `udev-gothic-nf` を追加

## Test plan
- [ ] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` が成功すること
- [ ] `nix build '.#homeConfigurations."nanasess@macbook".activationPackage'` が成功すること
- [ ] CI が通ること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 新しいフォント「Udev Gothic NF」をシステムに追加しました。このフォントをアプリケーションで利用できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->