### PR TITLE
feat: programs.ssh で SSH 設定を宣言的に管理

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -83,6 +83,19 @@
     JQ_COLORS = "1;36:0;33:0;33:0;36:0;32:1;39:1;39";
   };
 
+  programs.ssh = {
+    enable = true;
+    enableDefaultConfig = false;
+    includes = [
+      "~/.ssh/conf.d/*.conf"
+    ];
+    matchBlocks."*" = {
+      extraOptions = {
+        "IdentityAgent" = "~/.1password/agent.sock";
+      };
+    };
+  };
+
   home.file.".signature".text = ''
     Kentaro Ohkouchi
   '';


### PR DESCRIPTION
## Summary
- `programs.ssh` モジュールで `~/.ssh/config` を home-manager で宣言的に管理
- `Include ~/.ssh/conf.d/*.conf` により、プライベートな接続先設定を公開リポジトリ外で管理可能に
- `enableDefaultConfig = false` で将来の非推奨警告に対応

## Changes
- `home.nix` に `programs.ssh` セクションを追加
- 1Password SSH Agent (`IdentityAgent`) を `matchBlocks."*"` で設定
- プライベートリポジトリの SSH 設定は `~/.ssh/conf.d/` に配置して Include で読み込み

## Test plan
- [ ] `nix flake check` が通ること
- [ ] `home-manager switch` 後に `~/.ssh/config` が正しく生成されること
- [ ] SSH 接続が既存の設定と同様に動作すること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * SSH設定管理機能を追加しました。カスタムSSH設定ファイルの読み込みに対応し、1Passwordエージェント統合を有効にしました。これにより、SSH接続時の認証管理がより柔軟になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->