### PR TITLE
perf(emacs): 起動時間を最適化

### DIFF
--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -190,38 +190,27 @@
 ;;;; ============================================================
 (use-package ultra-scroll
   :ensure (:host github :repo "jdtsmith/ultra-scroll" :branch "main")
+  :init
+  (setq scroll-conservatively 3
+        scroll-margin 0)
   :hook (emacs-startup
          . (lambda ()
-             (pixel-scroll-precision-mode t)
-             (setopt scroll-conservatively 101
-                    scroll-margin 0
-                    scroll-step 1
-                    pixel-scroll-precision-use-momentum t
-                    pixel-scroll-precision-interpolate-mice t
-                    pixel-scroll-precision-large-scroll-height 10.0
-                    pixel-scroll-precision-interpolation-factor 1.0
-                    pixel-scroll-precision-interpolate-page t
-                    pixel-scroll-precision-interpolation-total-time 0.25)
+             (setopt pixel-scroll-precision-interpolation-total-time 0.15)
              (ultra-scroll-mode 1)
 
-             ;; https://www.reddit.com/r/emacs/comments/13accue/emacs_29_pixelscrollprecisionmode_seems_to_break/
-             (defun +pixel-scroll-interpolate-down ()
-               "Interpolate a scroll downwards by one page."
+             ;; emacs-inertial-scroll 風: ウィンドウの1/3をスムーススクロール
+             (defun my/scroll-down-smoothly ()
+               "Scroll down smoothly by 1/3 of window height."
                (interactive)
-               (if pixel-scroll-precision-interpolate-page
-                   (pixel-scroll-precision-interpolate
-                    (- (/ (window-text-height nil t) 2)) nil 1)
-                 (cua-scroll-up)))
-
-             (defun +pixel-scroll-interpolate-up ()
-               "Interpolate a scroll upwards by one page."
+               (pixel-scroll-precision-interpolate
+                (- (/ (window-text-height nil t) 3)) nil 1))
+             (defun my/scroll-up-smoothly ()
+               "Scroll up smoothly by 1/3 of window height."
                (interactive)
-               (if pixel-scroll-precision-interpolate-page
-                   (pixel-scroll-precision-interpolate
-                    (/ (window-text-height nil t) 2) nil 1)
-                 (cua-scroll-down)))
-             (global-set-key (kbd "C-v") '+pixel-scroll-interpolate-down)
-             (global-set-key (kbd "M-v") '+pixel-scroll-interpolate-up))))
+               (pixel-scroll-precision-interpolate
+                (/ (window-text-height nil t) 3) nil 1))
+             (global-set-key (kbd "C-v") 'my/scroll-down-smoothly)
+             (global-set-key (kbd "M-v") 'my/scroll-up-smoothly))))
 
 ;;;; ============================================================
 ;;;; Clipboard (pgtk / wl-clipboard)


### PR DESCRIPTION
## Summary
- Emacs の起動時間を最適化（バッチモード計測: 1.76s → 1.26s、約28%改善）
- ultra-scroll の設定を README 推奨に準拠させ、C-v/M-v のスクロール動作を改善

## Changes

### 起動時間の最適化
- 未使用の yasnippet / yasnippet-snippets を削除（-0.38s）
- consult-tramp に `:defer t` を追加（tramp チェーンの即時ロードを回避）
- oauth2 に `:defer t` を追加（url-http/mail-parse の連鎖ロードを回避）
- polymode / poly-markdown に `:defer t` を追加

### ultra-scroll の設定改善

以前 [nanasess/dotfiles](https://github.com/nanasess/dotfiles) で使用していた [kiwanami/emacs-inertial-scroll](https://github.com/kiwanami/emacs-inertial-scroll) の C-v/M-v スクロール動作を ultra-scroll + `pixel-scroll-precision-interpolate` で再現。

旧設定（emacs-inertial-scroll）:
```elisp
(setq inertias-initial-velocity 50)
(setq inertias-friction 120)
(setq inertias-update-time 60)
(setq inertias-rest-coef 0.1)
(global-set-key (kbd "C-v") 'inertias-up)
(global-set-key (kbd "M-v") 'inertias-down)
```

改善点:
- `pixel-scroll-precision-mode` の手動有効化を削除（ultra-scroll が内部で有効化するため不要）
- `pixel-scroll-precision-use-momentum`, `pixel-scroll-precision-interpolate-mice` 等の ultra-scroll と競合/不要な設定を削除
- `scroll-conservatively` を 101 → 3 に変更（ultra-scroll README 推奨値）
- C-v/M-v をウィンドウ高さの1/3のスムーススクロールに変更（旧 inertial-scroll 風の移動量）
- アニメーション時間を 0.15秒に設定（旧 `inertias-update-time: 60ms` に近い体感速度）

## Test plan
- [ ] `nix flake check` が通ること
- [ ] `nix build` が成功すること
- [ ] Emacs 起動時に起動時間が改善されていること
- [ ] consult-tramp, oauth2, polymode, poly-markdown が使用時に正しくロードされること
- [ ] C-v/M-v でウィンドウ1/3分のスムーススクロールが動作すること
- [ ] マウスホイールでの ultra-scroll が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)