### PR TITLE
feat: uv を Nix (home.packages) に追加

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -45,6 +45,7 @@
 
     # Development
     gh
+    uv
     terraform
     azure-cli
     awscli2


### PR DESCRIPTION
## Summary

- `uv` をスタンドアロンバイナリ (`~/.local/bin/uv`) から Nix (`home.packages`) 管理に移行

## Test plan

- [ ] `home-manager switch` 後に `which uv` が `~/.nix-profile/bin/uv` を指すこと
- [ ] `uv --version` が動作すること
- [ ] 旧バイナリ `~/.local/bin/uv` `~/.local/bin/uvx` を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * 開発環境で利用可能な開発ツールを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->