### PR TITLE
chore(portage): pipx と PHP_TARGETS を削除

### DIFF
--- a/modules/portage.nix
+++ b/modules/portage.nix
@@ -59,7 +59,6 @@
     ## default USE flags
     ## emerge --info | grep ^USE
     USE="keyring wayland gnome"
-    PHP_TARGETS="php8-2"
 
     COMMON_FLAGS="-march=znver3 -O2 -pipe"
     CHOST="x86_64-pc-linux-gnu"
@@ -97,7 +96,6 @@
     net-misc/onedrive
     sys-devel/gcc:15
     app-admin/cf-terraforming
-    dev-python/pipx
     dev-python/userpath
     dev-php/symfony-cli
     dev-python/pyfzf


### PR DESCRIPTION
## Summary
- `dev-python/pipx` をパッケージリストから削除
- `make.conf` から `PHP_TARGETS="php8-2"` を削除（PHP は削除済みのため不要）

## Test plan
- [ ] `nix flake check` が通ること
- [ ] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **設定変更**
  * PHP 8.2 のターゲット設定を削除しました
  * Python pipx パッケージのキーワード除外設定を削除しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->