### PR TITLE
feat(emacs): nix-mode を追加

### DIFF
--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -910,6 +910,11 @@
   :custom
   (terraform-format-on-save t))
 
+;;; Nix
+(use-package nix-mode
+  :ensure t
+  :mode "\\.nix\\'")
+
 ;;; Nginx
 (use-package nginx-mode
   :ensure t)


### PR DESCRIPTION
## Summary
- Emacs に nix-mode を追加し、`.nix` ファイル編集時のシンタックスハイライトとインデントを有効化

## Changes
- `modules/emacs/init.el` に `use-package nix-mode` の設定を追加
- `:mode "\\.nix\\'"` で `.nix` ファイルへの自動適用を設定

## Test plan
- [ ] Emacs 起動時に elpaca が nix-mode をインストールすることを確認
- [ ] `.nix` ファイルを開いてシンタックスハイライトが有効になることを確認
- [ ] `nix flake check` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Emacs で Nix ファイルの構文サポートを追加しました。`.nix` ファイルを開くと、自動的に言語モードが有効になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->