### PR TITLE
chore: flake.lock を更新し .gitignore に Emacs キャッシュを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 result
+modules/emacs/elpaca/
+modules/emacs/recentf

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775556024,
-        "narHash": "sha256-j1u/859OVS54rGlsvFqJdwKPEnFYCI+4pyfTiSfv1Xc=",
+        "lastModified": 1776046499,
+        "narHash": "sha256-Wzc4nn07/0RL21ypPHRzNDQZcjhIC8LaYo7QJQjM5T4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4bdfeff1d9b7473e6e58f73f5809576e8a69e406",
+        "rev": "287f84846c1eb3b72c986f5f6bebcff0bd67440d",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- nixpkgs と home-manager の flake 入力を最新版に更新
- Emacs の elpaca ビルドキャッシュ (`modules/emacs/elpaca/`) と recentf ファイルを `.gitignore` に追加

## Changes
- `flake.lock`: nixpkgs, home-manager のリビジョンを更新
- `.gitignore`: `modules/emacs/elpaca/` と `modules/emacs/recentf` を追加

## Test plan
- [x] `nix flake check` が通ること
- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore（保守）**
  * `.gitignore`に新しいパターンを追加し、特定のディレクトリをバージョン管理から除外するよう更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->