### PR TITLE
chore(emacs): elpaca.lock を更新し nix-mode を追加

### DIFF
--- a/modules/emacs/elpaca.lock
+++ b/modules/emacs/elpaca.lock
@@ -48,7 +48,7 @@
                    ("*" (:exclude ".git")) :source
                    "elpaca-menu-lock-file" :id compat :type git
                    :protocol https :inherit t :depth treeless :ref
-                   "3b603f0f4cd0a696a17a10486bcc65d6b9446b36"))
+                   "e4bd9aeb2893ef6304f471402e9659bb7a6d820c"))
  (composer :source "elpaca-menu-lock-file" :recipe
            (:package "composer" :fetcher github :repo
                      "emacs-php/composer.el" :files
@@ -90,7 +90,7 @@
                     :source "elpaca-menu-lock-file" :id consult :host
                     github :branch "main" :type git :protocol https
                     :inherit t :depth treeless :ref
-                    "080e2d6a5b20acf3f6c32ae0e1c88866853f3dfa"))
+                    "20476c690ce3ecd45460011ce6b03fd58a642181"))
  (consult-dir :source "elpaca-menu-lock-file" :recipe
               (:package "consult-dir" :fetcher github :repo
                         "karthink/consult-dir" :files
@@ -209,7 +209,7 @@
                           :source "elpaca-menu-lock-file" :id
                           doom-modeline :type git :protocol https
                           :inherit t :depth treeless :ref
-                          "043e8eeb0a6280cafdb6aef7bc4788d1392f55f4"))
+                          "870b4b215fda881d29278d81bbab7f934a9bd8b3"))
  (doom-themes :source "elpaca-menu-lock-file" :recipe
               (:package "doom-themes" :fetcher github :repo
                         "doomemacs/themes" :files
@@ -270,10 +270,10 @@
  (embark-consult :source "elpaca-menu-lock-file" :recipe
                  (:package "embark-consult" :repo "oantolin/embark"
                            :fetcher github :files
-                           ("embark-consult.el") :source "MELPA" :id
-                           embark-consult :host github :type git
-                           :protocol https :inherit t :depth treeless
-                           :ref
+                           ("embark-consult.el") :source
+                           "elpaca-menu-lock-file" :id embark-consult
+                           :host github :type git :protocol https
+                           :inherit t :depth treeless :ref
                            "27de48004242e98586b9c9661fdb6912f26fe70f"))
  (expand-region :source "elpaca-menu-lock-file" :recipe
                 (:package "expand-region" :repo
@@ -383,8 +383,8 @@
                   (:exclude ".dir-locals.el" "test.el" "tests.el"
                             "*-test.el" "*-tests.el" "LICENSE"
                             "README*" "*-pkg.el"))
-                 :source "MELPA" :id howm :type git :protocol https
-                 :inherit t :depth treeless :ref
+                 :source "elpaca-menu-lock-file" :id howm :type git
+                 :protocol https :inherit t :depth treeless :ref
                  "7e49045c23749b61d8c93df68ad9502292fd61bc"))
  (ht :source "elpaca-menu-lock-file" :recipe
      (:package "ht" :fetcher github :repo "Wilfred/ht.el" :files
@@ -426,7 +426,7 @@
                    (:exclude "lisp/magit-section.el"))
                   :source "elpaca-menu-lock-file" :id magit :type git
                   :protocol https :inherit t :depth treeless :ref
-                  "6db34dc77d10fc9b8c925e79b4e0e21d9f78ac5c"))
+                  "4a1c6389e70b80152160e265738dd87e60fef496"))
  (magit-section :source "elpaca-menu-lock-file" :recipe
                 (:package "magit-section" :fetcher github :repo
                           "magit/magit" :files
@@ -436,7 +436,7 @@
                           :source "elpaca-menu-lock-file" :id
                           magit-section :type git :protocol https
                           :inherit t :depth treeless :ref
-                          "6db34dc77d10fc9b8c925e79b4e0e21d9f78ac5c"))
+                          "4a1c6389e70b80152160e265738dd87e60fef496"))
  (marginalia :source "elpaca-menu-lock-file" :recipe
              (:package "marginalia" :repo "minad/marginalia" :fetcher
                        github :files
@@ -525,7 +525,7 @@
                              :source "elpaca-menu-lock-file" :id
                              multiple-cursors :type git :protocol
                              https :inherit t :depth treeless :ref
-                             "ddd677091afc7d65ce56d11866e18aeded110ada"))
+                             "6f984c6e1d5f144027d2b6eafb6b77744fb2f8d5"))
  (nerd-icons :source "elpaca-menu-lock-file" :recipe
              (:package "nerd-icons" :repo
                        "rainstormstudio/nerd-icons.el" :fetcher github
@@ -549,6 +549,14 @@
                        :type git :protocol https :inherit t :depth
                        treeless :ref
                        "c4ac5de975d65c84893a130a470af32a48b0b66c"))
+ (nix-mode :source "elpaca-menu-lock-file" :recipe
+           (:package "nix-mode" :fetcher github :repo "NixOS/nix-mode"
+                     :files
+                     (:defaults
+                      (:exclude "nix-company.el" "nix-mode-mmm.el"))
+                     :source "MELPA" :id nix-mode :type git :protocol
+                     https :inherit t :depth treeless :ref
+                     "719feb7868fb567ecfe5578f6119892c771ac5e5"))
  (nskk :source "elpaca-menu-lock-file" :recipe
        (:source "elpaca-menu-lock-file" :package "nskk" :id nskk :host
                 github :repo "takeokunn/nskk.el" :branch "main" :build
@@ -850,7 +858,7 @@
                       :source "elpaca-menu-lock-file" :id transient
                       :type git :protocol https :inherit t :depth
                       treeless :ref
-                      "8b14203107950d6eba0e17d14867e05547725219"))
+                      "e4e5f2ab1701ccc19d25361f1c574da6d33ac080"))
  (ultra-scroll :source "elpaca-menu-lock-file" :recipe
                (:package "ultra-scroll" :fetcher github :repo
                          "jdtsmith/ultra-scroll" :files
@@ -919,20 +927,21 @@
                   :source "elpaca-menu-lock-file" :id wgrep :type git
                   :protocol https :inherit t :depth treeless :ref
                   "49f09ab9b706d2312cab1199e1eeb1bcd3f27f6f"))
- (with-editor :source "elpaca-menu-lock-file"
-   :recipe
-   (:package "with-editor" :fetcher github :repo "magit/with-editor"
-             :files
-             ("*.el" "*.el.in" "dir" "*.info" "*.texi" "*.texinfo"
-              "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
-              "lisp/*.el" "docs/dir" "docs/*.info" "docs/*.texi"
-              "docs/*.texinfo"
-              (:exclude ".dir-locals.el" "test.el" "tests.el"
-                        "*-test.el" "*-tests.el" "LICENSE" "README*"
-                        "*-pkg.el"))
-             :source "elpaca-menu-lock-file" :id with-editor :type git
-             :protocol https :inherit t :depth treeless :ref
-             "64211dcb815f2533ac3d2a7e56ff36ae804d8338"))
+ (with-editor :source "elpaca-menu-lock-file" :recipe
+              (:package "with-editor" :fetcher github :repo
+                        "magit/with-editor" :files
+                        ("*.el" "*.el.in" "dir" "*.info" "*.texi"
+                         "*.texinfo" "doc/dir" "doc/*.info"
+                         "doc/*.texi" "doc/*.texinfo" "lisp/*.el"
+                         "docs/dir" "docs/*.info" "docs/*.texi"
+                         "docs/*.texinfo"
+                         (:exclude ".dir-locals.el" "test.el"
+                                   "tests.el" "*-test.el" "*-tests.el"
+                                   "LICENSE" "README*" "*-pkg.el"))
+                        :source "elpaca-menu-lock-file" :id
+                        with-editor :type git :protocol https :inherit
+                        t :depth treeless :ref
+                        "64211dcb815f2533ac3d2a7e56ff36ae804d8338"))
  (yaml-mode :source "elpaca-menu-lock-file" :recipe
             (:package "yaml-mode" :repo "yoshiki/yaml-mode" :fetcher
                       github :files


### PR DESCRIPTION
## Summary
- elpaca パッケージのバージョンを更新
- 新規パッケージ `nix-mode` を追加

## Changes
- **バージョン更新**: compat, consult, doom-modeline, magit, magit-section, multiple-cursors, transient
- **新規追加**: nix-mode (NixOS/nix-mode)
- **ソース修正**: embark-consult, howm のソースを MELPA から elpaca-menu-lock-file に統一

## Test plan
- [ ] `nix flake check` が通ること
- [ ] `emacs --batch` による init.el 読み込みテストが通ること
- [ ] 各ホストの `activationPackage` ビルドが成功すること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)