### PR TITLE
feat(nix): poppler-utils を追加

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -28,6 +28,7 @@
     ffmpeg
     whois
     pandoc
+    poppler-utils
     lftp
     pigz
     zip


### PR DESCRIPTION
## Summary
- `poppler-utils` (pdftotext, pdfinfo 等) を home.packages に追加

## Changes
- `home.nix` の CLI tools セクションに `poppler-utils` を追加

## Test plan
- [x] `nix build` でビルド成功を確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Home Manager プロファイルで `poppler-utils` パッケージが利用可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->