### PR TITLE
fix(emacs): package-enable-at-startup の setopt を setq に戻す

### DIFF
--- a/modules/emacs/early-init.el
+++ b/modules/emacs/early-init.el
@@ -21,7 +21,7 @@
 (push '(foreground-color . "#657B83") default-frame-alist)
 
 ;; elpaca takes over package management
-(setopt package-enable-at-startup nil)
+(setq package-enable-at-startup nil)
 
 (with-eval-after-load 'comp
   (setopt native-comp-async-jobs-number (num-processors))


### PR DESCRIPTION
## Summary
- `early-init.el` の `package-enable-at-startup` 設定を `setopt` から `setq` に戻し、起動時の「Package.el loaded before Elpaca」警告を修正

## Changes
- `setopt` は内部的に `customize-set-variable` を呼び出し、`defcustom` の定義検証のために `package.el` を自動ロードする
- これにより elpaca のセットアップより先に `package.el` が読み込まれ、警告が発生していた
- `setq` は単純な変数代入のため `package.el` のロードを引き起こさない

## Test plan
- [ ] `nix build` でビルドが成功すること
- [ ] Emacs 起動時に「Package.el loaded before Elpaca」警告が表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Emacs初期化設定の調整を実施しました。ユーザー向けの機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->