### PR TITLE
refactor: emacs と onedrive を Gentoo (portage) から Nix に移行

### DIFF
--- a/hosts/ubuntu.nix
+++ b/hosts/ubuntu.nix
@@ -65,7 +65,6 @@ in
 
   home.packages = with pkgs; [
     emacs30
-    onedrive
     walker
     libqalculate
   ];
@@ -88,22 +87,6 @@ in
       ${pkgs.dconf}/bin/dconf write "$profile_path/audible-bell" false
     fi
   '';
-
-  systemd.user.services.onedrive = {
-    Unit = {
-      Description = "OneDrive Free Client";
-      After = [ "network-online.target" ];
-      Wants = [ "network-online.target" ];
-    };
-    Service = {
-      ExecStart = "${pkgs.onedrive}/bin/onedrive --monitor";
-      Restart = "on-failure";
-      RestartSec = 3;
-    };
-    Install = {
-      WantedBy = [ "default.target" ];
-    };
-  };
 
   dconf.settings = {
     "org/gnome/settings-daemon/plugins/media-keys" = {

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -10,13 +10,11 @@ let
     "app-portage/mirrorselect"
     "dev-util/pkgdev"
     "dev-util/pkgcheck"
-    "net-misc/onedrive"
     "www-client/google-chrome"
     "x11-misc/xvfb-run"
     "x11-apps/mesa-progs"
     "x11-apps/xeyes"
     "app-shells/zsh"
-    "app-editors/emacs" # #49 検証中
     "sys-apps/plocate"
 
     # mise PHP ビルド依存（asdf-php workflow.yml 参照）

--- a/modules/onedrive.nix
+++ b/modules/onedrive.nix
@@ -1,6 +1,8 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
+  home.packages = [ pkgs.onedrive ];
+
   xdg.configFile."onedrive/config".text = ''
     sync_dir = "~/OneDrive - Skirnir Inc"
   '';
@@ -8,4 +10,20 @@
   xdg.configFile."onedrive/sync_list".text = ''
     emacs
   '';
+
+  systemd.user.services.onedrive = {
+    Unit = {
+      Description = "OneDrive Free Client";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+    };
+    Service = {
+      ExecStart = "${pkgs.onedrive}/bin/onedrive --monitor";
+      Restart = "on-failure";
+      RestartSec = 3;
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
 }

--- a/modules/portage.nix
+++ b/modules/portage.nix
@@ -82,7 +82,6 @@
     # Please keep this setting intact when reporting bugs.
     LC_MESSAGES=C.utf8
 
-    EGIT_OVERRIDE_REPO_EMACS="https://github.com/emacs-mirror/emacs.git"
     GENTOO_MIRRORS="http://ftp.iij.ad.jp/pub/linux/gentoo/ \
         https://ftp.jaist.ac.jp/pub/Linux/Gentoo/ \
         https://repo.jing.rocks/gentoo \
@@ -92,20 +91,13 @@
   # #48 移行済みパッケージを除外
   xdg.configFile."portage/package.accept_keywords".text = ''
     dev-python/sqlglot
-    app-editors/emacs **
-    net-misc/onedrive
     sys-devel/gcc:15
     app-admin/cf-terraforming
     dev-python/userpath
 
     dev-python/pyfzf
-    app-emacs/emacs-common
     dev-python/click
     media-libs/mesa
-  '';
-
-  xdg.configFile."portage/package.mask".text = ''
-    >app-editors/emacs-31
   '';
 
   xdg.configFile."portage/package.unmask".text = ''
@@ -120,15 +112,6 @@
     www-client/google-chrome google-chrome
   '';
 
-  # package.use: #49 検証中
-  xdg.configFile."portage/package.use/emacs".text = ''
-    app-editors/emacs xft -gsettings gconf gtk -athena -Xaw3d dynamic-loading gif gui gzip-el harfbuzz imagemagick jpeg json libxml2 livecd m17n-lib mailutils png svg tiff toolkit-scroll-bars wide-int xwidgets cairo jit tree-sitter X webp sqlite ssl tools -pgtk
-    # required by app-editors/emacs-29.3-r2::gentoo[jit]
-    # required by @selected
-    # required by @world (argument)
-    >=sys-devel/gcc-13.2.1_p20240210 jit
-  '';
-
   xdg.configFile."portage/package.use/ffmpeg".text = ''
     media-video/ffmpeg libass lzma opus pulseaudio theora vpx
     media-libs/libsdl2 gles2 pipewire pulseaudio
@@ -141,11 +124,6 @@
   xdg.configFile."portage/package.use/gnupg".text = ''
     app-crypt/gpgme -qt5 -qt6
     app-crypt/gnupg -usb
-  '';
-
-  xdg.configFile."portage/package.use/onedrive".text = ''
-    net-misc/onedrive libnotify dmd-2_105
-    sys-devel/gcc d
   '';
 
   # pg_config とヘッダのみ必要（mise PHP ビルド用）、サーバ不要


### PR DESCRIPTION
## Summary

- Nix の emacs が安定したため、Gentoo の `app-editors/emacs` を削除し Nix パッケージに一本化
- `net-misc/onedrive` も Nix パッケージ + home-manager systemd ユーザーサービスに移行
- portage.nix から emacs/onedrive 関連の設定をすべて削除（`sys-devel/gcc d` 含む）

## Changes

- `hosts/wsl-gentoo.nix`: `gentooPackages` から `app-editors/emacs`, `net-misc/onedrive` を削除
- `modules/portage.nix`: emacs/onedrive 関連の portage 設定を削除
  - `EGIT_OVERRIDE_REPO_EMACS` (make.conf)
  - `package.accept_keywords` (emacs, emacs-common, onedrive)
  - `package.mask` (emacs-31) — 空になったためセクションごと削除
  - `package.use/emacs` (USE フラグ + gcc jit)
  - `package.use/onedrive` (libnotify, dmd, gcc d)
- `modules/onedrive.nix`: onedrive パッケージと systemd ユーザーサービスを集約
- `hosts/ubuntu.nix`: 重複する onedrive パッケージ・systemd サービスを削除

## Test plan

- [x] `nix flake check` 通過
- [x] `home-manager switch --flake '.#nanasess@wsl-gentoo'` 適用済み
- [x] Nix の onedrive systemd ユーザーサービスが正常稼動を確認
- [x] CI (build matrix) の通過を確認

Closes #48 (emacs, onedrive の移行完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * OneDrive統合の設定をモジュール化して、複数環境での管理を改善しました
  * 特定のホスト環境（Ubuntu、WSL Gentoo）からOneDriveとEmacsのサポートを削除し、設定をシンプル化しました
  * パッケージ管理の設定を最適化して、不要なオーバーライド設定を削除しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->