### PR TITLE
fix(wezterm): Claude Code TUI の描画崩れを改善

### DIFF
--- a/modules/wezterm/wezterm.lua
+++ b/modules/wezterm/wezterm.lua
@@ -22,6 +22,9 @@ config.font_size = 14.0
 -- locale-eaw EAW-CONSOLE に合わせた文字幅設定
 -- https://github.com/hamano/locale-eaw
 local eaw = dofile(wezterm.config_dir .. '/.eaw-console-wezterm.lua')
+-- Claude Code TUI との互換性のため特定の記号を半角に戻す
+table.insert(eaw, {first = 0x23bf, last = 0x23bf, width = 1})  -- ⎿
+table.insert(eaw, {first = 0x25cf, last = 0x25cf, width = 1})  -- ●
 config.cell_widths = eaw
 
 local spawn_tab_in_home = wezterm.action.SpawnCommandInNewTab {


### PR DESCRIPTION
## Summary

- locale-eaw EAW-CONSOLE の `cell_widths` と Claude Code TUI の文字幅計算の不整合による描画崩れを改善
- Claude Code が使用する `●` (U+25CF) と `⎿` (U+23BF) を `cell_widths` で半角に戻す

## Background

Claude Code の TUI レンダリングは標準 Unicode 幅テーブル (Ambiguous=1) を使用するため、locale-eaw の `cell_widths` (Ambiguous=2) と不整合が発生し、レイアウトが崩れる。

| 文字 | JPDOC グリフ | cell_widths | Claude Code 内部 | 対策 |
|------|------------|------------|----------------|------|
| `●` U+25CF | 全角 (2.0) | 2 → **1** | 1 | 半角に戻す |
| `⎿ ` U+23BF | 全角 (2.0) | 1 → **1** (明示) | 1 | 明示的に半角指定 |

Related: anthropics/claude-code#35560, anthropics/claude-code#40323

## Test plan

- [x] `nix build` 通過
- [x] Claude Code TUI の描画が改善されることを確認
- [x] ターミナル (zsh) の △→○● 表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善
* ターミナル内の特定の記号文字の表示幅を調整し、レイアウトの正確性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->