### PR TITLE
fix(zsh): dotDir の非推奨な相対パス指定を絶対パスに修正

### DIFF
--- a/modules/zsh/default.nix
+++ b/modules/zsh/default.nix
@@ -3,7 +3,7 @@
 {
   programs.zsh = {
     enable = true;
-    dotDir = ".config/zsh";
+    dotDir = "${config.xdg.configHome}/zsh";
 
     envExtra = ''
       export CLAUDE_CONFIG_DIR=$HOME/.config/claude


### PR DESCRIPTION
## Summary
- `programs.zsh.dotDir` の相対パス指定が Home Manager で非推奨となった warning を修正
- `".config/zsh"` → `"${config.xdg.configHome}/zsh"` に変更

## Changes
- `modules/zsh/default.nix`: `dotDir` を `config.xdg.configHome` を使用した絶対パスに変更

## Test plan
- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` で `dotDir` の warning が消えることを確認
- [x] `home-manager switch` 後に Zsh の設定ファイルが `~/.config/zsh/` に正しく配置されることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)