### PR TITLE
chore(portage,zsh): dotnet 関連設定を削除

### DIFF
--- a/modules/portage.nix
+++ b/modules/portage.nix
@@ -102,7 +102,6 @@
 
   xdg.configFile."portage/package.unmask".text = ''
     >=www-client/google-chrome-126.0.6478.55
-    >=virtual/dotnet-sdk-9.0
     # mycli-1.41.2の依存関係
     dev-python/click
   '';

--- a/modules/zsh/default.nix
+++ b/modules/zsh/default.nix
@@ -108,7 +108,6 @@
         # PATH
         export PATH=$HOME/bin:$HOME/go/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH
         export PATH=$HOME/.composer/vendor/bin:~/.npm-global/bin:$PATH
-        export PATH=$HOME/.dotnet/tools:$PATH
         export PATH=$HOME/.rbenv/bin:$PATH
         export PATH=$HOME/.symfony/bin:$HOME/.symfony5/bin:$PATH
         export PATH=$HOME/google-cloud-sdk/bin:$PATH


### PR DESCRIPTION
## Summary
- Gentoo パッケージから `dev-dotnet/omnisharp-roslyn` と dotnet-sdk を削除したため、home-manager 側の関連設定も削除。

## Changes
- `modules/portage.nix`: `package.unmask` から `>=virtual/dotnet-sdk-9.0` を削除
- `modules/zsh/default.nix`: PATH から `$HOME/.dotnet/tools` を削除

なお `modules/zsh/.p10k.zsh` にも dotnet 関連の記述はあるが、p10k configure 生成テンプレートのため今回は変更対象外。

## Test plan
- [x] `nix build '.#homeConfigurations.\"nanasess@wsl-gentoo\".activationPackage'` が成功することを確認
- [ ] CI (`nix flake check` 等) がグリーンであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の変更**
  * .NET SDK関連の設定をシステム構成から削除しました
  * シェル環境から.NET CLIツールパスの参照を削除しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->