### PR TITLE
feat(ghostty): Windows port (PR #12167) 対応の共有設定モジュールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ home-manager switch --flake '.#nanasess@wsl-gentoo' --dry-run
 flake.nix              -- エントリポイント（inputs と homeConfigurations）
 home.nix               -- 全ホスト共通設定（パッケージ、git、direnv、環境変数）
 hosts/
-  wsl-gentoo.nix       -- WSL Gentoo 固有設定（WezTerm コピー、1Password CLI、WSLg X11/Wayland）
+  wsl-gentoo.nix       -- WSL Gentoo 固有設定（WezTerm / Ghostty コピー、1Password CLI、WSLg X11/Wayland）
   ubuntu.nix           -- Ubuntu 固有設定（Ghostty、Walker、OneDrive）
   macos.nix            -- macOS 固有設定
 modules/
@@ -86,6 +86,8 @@ modules/
     eaw-console.el     -- Emacs char-width-table 設定
   wezterm/
     wezterm.lua        -- WezTerm 設定（WSL → Windows 側にコピー）
+  ghostty/
+    default.nix        -- Ghostty 共有設定（Linux native / Windows port (PR #12167) 両対応、_module.args で公開）
   portage.nix          -- Portage 設定（WSL Gentoo 用、xdg.configFile で ~/.config/portage/ に書き出し）
   onedrive.nix         -- OneDrive 設定（WSL Gentoo 用）
 .github/workflows/
@@ -108,6 +110,7 @@ modules/
 | Emacs Elisp パッケージ | elpaca + use-package | 柔軟性、ロックファイルによるバージョン固定 |
 | Emacs ネイティブ依存 | Nix (cmigemo 等) | ビルド依存の解決 |
 | WezTerm 設定 | home-manager → activation copy | WSL 側から Windows 側 (`/mnt/c/Users/nanasess/`) にコピー |
+| Ghostty 設定 | 共有 Nix attrset + renderer | `programs.ghostty.settings` (Linux native) と `%LOCALAPPDATA%\ghostty\config.ghostty` (Windows port) を同一 attrset から生成 |
 | East Asian Ambiguous 文字幅 | locale-eaw EAW-CONSOLE | glibc wcwidth + WezTerm cell_widths + Emacs char-width-table を統一 |
 | Portage 設定 | home-manager (xdg.configFile) | `~/.config/portage/` に書き出し、`/etc/portage/` から個別にシンボリックリンク |
 | システムパッケージ一覧 | Nix リスト + チェックスクリプト | 各ホストの nix ファイルで宣言、`check-system-packages` で差分確認 |

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       homeConfigurations = {
         "nanasess@wsl-gentoo" = home-manager.lib.homeManagerConfiguration {
           pkgs = nixpkgs.legacyPackages.x86_64-linux;
-          modules = [ ./home.nix ./hosts/wsl-gentoo.nix ./modules/onedrive.nix ./modules/portage.nix ./modules/locale-eaw ./modules/emacs ./modules/zsh ];
+          modules = [ ./home.nix ./hosts/wsl-gentoo.nix ./modules/onedrive.nix ./modules/portage.nix ./modules/locale-eaw ./modules/emacs ./modules/zsh ./modules/ghostty ];
         };
         "nanasess@macbook" = home-manager.lib.homeManagerConfiguration {
           pkgs = nixpkgs.legacyPackages.x86_64-darwin;
@@ -40,6 +40,7 @@
             ./modules/onedrive.nix
             ./modules/emacs
             ./modules/zsh
+            ./modules/ghostty
             {
               nixGL.packages = nixgl.packages;
             }

--- a/hosts/ubuntu.nix
+++ b/hosts/ubuntu.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, ghostty, ... }:
 
 let
   # apt で管理するパッケージ一覧
@@ -15,15 +15,7 @@ in
   programs.ghostty = {
     enable = true;
     package = config.lib.nixGL.wrap pkgs.ghostty;
-    settings = {
-      font-family = "Ubuntu Sans Mono";
-      font-size = 13;
-      keybind = [
-        "ctrl+l=next_tab"
-        "ctrl+h=previous_tab"
-      ];
-      theme = "Solarized Dark Patched";
-    };
+    settings = ghostty.settings;
   };
 
   home.file.".local/share/applications/com.mitchellh.ghostty.desktop".text = ''

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, ghostty, ... }:
 
 let
   # Gentoo (portage) で管理するパッケージ一覧
@@ -56,11 +56,25 @@ in
     install -Dm644 ${../modules/locale-eaw/eaw-console-wezterm.lua} /mnt/c/Users/${config.home.username}/.eaw-console-wezterm.lua
   '';
 
-  # UDEV Gothic JPDOC フォントを Windows 側にコピー (WezTerm font_dirs 用)
+  # UDEV Gothic JPDOC / NF フォントを Windows 側にコピー
+  # (WezTerm font_dirs / Ghostty Windows font directory scan の両方から参照される)
   home.activation.weztermFonts = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     fontdir="/mnt/c/Users/${config.home.username}/.local/share/fonts"
     mkdir -p "$fontdir"
     install -m644 ${pkgs.udev-gothic}/share/fonts/udev-gothic/UDEVGothicJPDOC-*.ttf "$fontdir/"
+    install -m644 ${pkgs.udev-gothic-nf}/share/fonts/udev-gothic-nf/UDEVGothicNF-*.ttf "$fontdir/"
+  '';
+
+  # Ghostty Windows port (PR #12167) 向け設定を %LOCALAPPDATA%\ghostty\ にコピー
+  # Windows 版は LOCALAPPDATA 配下の config.ghostty を読む
+  # また Windows 版には themes/ が同梱されていないため、Nix パッケージ付属の
+  # themes/ を %LOCALAPPDATA%\ghostty\themes\ に同期する (テーマ指定が効かない問題の対処)
+  home.activation.ghosttyConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    ghostty_dir="/mnt/c/Users/${config.home.username}/AppData/Local/ghostty"
+    install -Dm644 ${ghostty.configFile} "$ghostty_dir/config.ghostty"
+    mkdir -p "$ghostty_dir/themes"
+    ${pkgs.rsync}/bin/rsync -a --delete \
+      ${pkgs.ghostty}/share/ghostty/themes/ "$ghostty_dir/themes/"
   '';
 
 
@@ -104,6 +118,65 @@ in
         echo "$missing 個のパッケージが未インストールです"
         exit 1
       fi
+    '';
+  };
+
+  # Ghostty Windows port は C:\Windows\Fonts のみをスキャンするため
+  # (src/font/SharedGridSet.zig の findWindowsFont 参照)、
+  # ユーザーフォント (~/.local/share/fonts) からシステムフォントに
+  # ワンショットでコピーするヘルパー (UAC 昇格が発生する)
+  #
+  # .ps1 を一時ファイルに書き出してから Start-Process -Verb RunAs で実行することで、
+  # 多段クォートのトラブル・静かな失敗・ウィンドウ即閉じによる情報欠落を回避する
+  home.file.".local/bin/install-ghostty-windows-fonts" = {
+    executable = true;
+    text = ''
+      #!/bin/bash
+      set -e
+      user='${config.home.username}'
+      src_dir="/mnt/c/Users/$user/.local/share/fonts"
+      ps1_wsl="$src_dir/.install-ghostty-fonts.ps1"
+      ps1_win="C:\\Users\\$user\\.local\\share\\fonts\\.install-ghostty-fonts.ps1"
+      PSH='/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe'
+
+      if [ ! -x "$PSH" ]; then
+        echo "ERROR: $PSH が見つかりません" >&2
+        exit 1
+      fi
+
+      if ! ls "$src_dir"/UDEVGothic*.ttf >/dev/null 2>&1; then
+        echo "ERROR: $src_dir に UDEVGothic*.ttf が見つかりません" >&2
+        echo "まず 'home-manager switch --flake \".#nanasess@wsl-gentoo\"' を実行してください" >&2
+        exit 1
+      fi
+
+      cat > "$ps1_wsl" <<'EOF'
+      $ErrorActionPreference = 'Stop'
+      $src = Join-Path $env:USERPROFILE '.local\share\fonts'
+      $dst = Join-Path $env:WINDIR 'Fonts'
+      $files = Get-ChildItem -Path $src -Filter 'UDEVGothic*.ttf'
+      if ($files.Count -eq 0) {
+          Write-Host "ERROR: UDEVGothic*.ttf not found in $src"
+          Read-Host 'Press Enter to close'
+          exit 1
+      }
+      foreach ($f in $files) {
+          Copy-Item -Path $f.FullName -Destination $dst -Force
+          Write-Host "Copied: $($f.Name)"
+      }
+      Write-Host ""
+      Write-Host "Done. Copied $($files.Count) file(s) to $dst"
+      Start-Sleep -Seconds 2
+      EOF
+
+      echo "UAC 昇格プロンプトが出ます。[はい] で許可してください。"
+      "$PSH" -NoProfile -Command \
+        "Start-Process powershell -Verb RunAs -Wait -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','$ps1_win'"
+
+      rm -f "$ps1_wsl"
+      echo ""
+      echo "--- コピー結果の確認 ---"
+      ls /mnt/c/Windows/Fonts/UDEVGothic*.ttf 2>/dev/null || echo "(まだ見つかりません — UAC を拒否したか、別の理由で失敗しています)"
     '';
   };
 

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -73,7 +73,7 @@ in
     ghostty_dir="/mnt/c/Users/${config.home.username}/AppData/Local/ghostty"
     install -Dm644 ${ghostty.configFile} "$ghostty_dir/config.ghostty"
     mkdir -p "$ghostty_dir/themes"
-    ${pkgs.rsync}/bin/rsync -a --delete \
+    ${pkgs.rsync}/bin/rsync -rt --delete \
       ${pkgs.ghostty}/share/ghostty/themes/ "$ghostty_dir/themes/"
   '';
 

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -126,8 +126,9 @@ in
   # ユーザーフォント (~/.local/share/fonts) からシステムフォントに
   # ワンショットでコピーするヘルパー (UAC 昇格が発生する)
   #
-  # .ps1 を一時ファイルに書き出してから Start-Process -Verb RunAs で実行することで、
-  # 多段クォートのトラブル・静かな失敗・ウィンドウ即閉じによる情報欠落を回避する
+  # PowerShell スクリプトは UTF-16LE + base64 化して -EncodedCommand で
+  # 直接引数として渡す。中間 .ps1 ファイルを作らないので、ユーザー書込可能な
+  # 場所のファイルを昇格実行する際の TOCTOU リスクを回避できる
   home.file.".local/bin/install-ghostty-windows-fonts" = {
     executable = true;
     text = ''
@@ -135,8 +136,6 @@ in
       set -e
       user='${config.home.username}'
       src_dir="/mnt/c/Users/$user/.local/share/fonts"
-      ps1_wsl="$src_dir/.install-ghostty-fonts.ps1"
-      ps1_win="C:\\Users\\$user\\.local\\share\\fonts\\.install-ghostty-fonts.ps1"
       PSH='/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe'
 
       if [ ! -x "$PSH" ]; then
@@ -150,7 +149,7 @@ in
         exit 1
       fi
 
-      cat > "$ps1_wsl" <<'EOF'
+      read -r -d "" ps_script <<'EOF' || true
       $ErrorActionPreference = 'Stop'
       $src = Join-Path $env:USERPROFILE '.local\share\fonts'
       $dst = Join-Path $env:WINDIR 'Fonts'
@@ -169,11 +168,13 @@ in
       Start-Sleep -Seconds 2
       EOF
 
+      # PowerShell -EncodedCommand は UTF-16LE base64 を要求する
+      encoded=$(printf '%s' "$ps_script" | iconv -t UTF-16LE | base64 -w 0)
+
       echo "UAC 昇格プロンプトが出ます。[はい] で許可してください。"
       "$PSH" -NoProfile -Command \
-        "Start-Process powershell -Verb RunAs -Wait -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','$ps1_win'"
+        "Start-Process powershell -Verb RunAs -Wait -ArgumentList '-NoProfile','-EncodedCommand','$encoded'"
 
-      rm -f "$ps1_wsl"
       echo ""
       echo "--- コピー結果の確認 ---"
       ls /mnt/c/Windows/Fonts/UDEVGothic*.ttf 2>/dev/null || echo "(まだ見つかりません — UAC を拒否したか、別の理由で失敗しています)"

--- a/modules/ghostty/default.nix
+++ b/modules/ghostty/default.nix
@@ -1,0 +1,48 @@
+{ pkgs, lib, ... }:
+
+let
+  # 全ホスト共通の Ghostty 設定
+  # Linux (home-manager programs.ghostty.settings) と Windows port
+  # (%LOCALAPPDATA%\ghostty\config.ghostty) で共有する
+  settings = {
+    # UDEV Gothic JPDOC をプライマリ、NF を Nerd Font フォールバックとして使用
+    # (WezTerm 設定と合わせる。modules/wezterm/wezterm.lua 参照)
+    font-family = [
+      "UDEV Gothic JPDOC"
+      "UDEV Gothic NF"
+    ];
+    font-size = 13;
+    keybind = [
+      "ctrl+l=next_tab"
+      "ctrl+h=previous_tab"
+    ];
+    theme = "iTerm2 Solarized Light";
+  };
+
+  # Windows 版固有の追加設定
+  # - command: 起動時に WSL の Gentoo-systemd ディストリをログインシェルで立ち上げる
+  #   "direct:" プレフィックスを付けて /bin/sh -c ラップを回避 (Windows には sh が無い)
+  #   --cd ~ でホームディレクトリに入る (WezTerm の default_cwd と等価)
+  # - font-family: Segoe UI Symbol を追加フォールバック
+  #   Ghostty 自動フォールバックリスト (CodepointResolver.zig) に seguisym.ttf が
+  #   含まれておらず、U+23F5 (⏵) 等の記号が豆腐になるため明示指定
+  windowsSettings = settings // {
+    command = "direct:wsl.exe -d Gentoo-systemd --cd ~";
+    font-family = settings.font-family ++ [ "Segoe UI Symbol" ];
+  };
+
+  # home-manager の programs.ghostty が内部で使っているのと同じフォーマッタ
+  # (listsAsDuplicateKeys = true で keybind = ... 行を複数行に展開)
+  renderConfig = lib.generators.toKeyValue {
+    mkKeyValue = lib.generators.mkKeyValueDefault { } " = ";
+    listsAsDuplicateKeys = true;
+  };
+
+  configFile = pkgs.writeText "ghostty-config.ghostty" (renderConfig windowsSettings);
+in
+{
+  # settings / configFile を他のモジュール (hosts/*.nix) から参照できるように公開
+  _module.args.ghostty = {
+    inherit settings configFile;
+  };
+}

--- a/modules/ghostty/default.nix
+++ b/modules/ghostty/default.nix
@@ -17,6 +17,10 @@ let
       "ctrl+h=previous_tab"
     ];
     theme = "iTerm2 Solarized Light";
+    # マウス選択で通常クリップボードにコピー (Ctrl+V で貼付可能)
+    # Linux では selection clipboard にも入るので中クリックペーストも維持される
+    # Windows のデフォルトは false, Linux のデフォルトは true (selection のみ)
+    copy-on-select = "clipboard";
   };
 
   # Windows 版固有の追加設定


### PR DESCRIPTION
## Summary

- Ghostty Windows port ([ghostty-org/ghostty#12167](https://github.com/ghostty-org/ghostty/pull/12167)) に対応する共有設定モジュールを新設
- Linux (home-manager `programs.ghostty.settings`) と Windows (`%LOCALAPPDATA%\ghostty\config.ghostty`) を同一 Nix attrset から生成し、Ubuntu/wsl-gentoo ホスト間で設定を共有
- WezTerm と同じ UDEV Gothic JPDOC/NF を使用、theme は iTerm2 Solarized Light に統一

## Changes

### modules/ghostty/ (新規)
- 共有 `settings` と rendered derivation `configFile` を `_module.args.ghostty` 経由で公開
- `lib.generators.toKeyValue` で `listsAsDuplicateKeys = true` を有効化し、Ghostty 設定形式 (key = value / 重複キー) でレンダ
- `windowsSettings` は `settings` に以下を追加:
  - `command = direct:wsl.exe -d Gentoo-systemd --cd ~` — WSL Gentoo-systemd に直接ログイン (`direct:` で `/bin/sh -c` ラップ回避)
  - `font-family` フォールバックに `Segoe UI Symbol` を追加 — Ghostty の Windows 自動フォールバックリスト (`src/font/CodepointResolver.zig`) に `seguisym.ttf` が無く、U+23F5 (⏵) 等の記号が豆腐になる問題への対処

### hosts/wsl-gentoo.nix
- `home.activation.ghosttyConfig`: `%LOCALAPPDATA%\ghostty\config.ghostty` を install し、`pkgs.ghostty` 付属の `themes/` (463 個) を `%LOCALAPPDATA%\ghostty\themes\` に rsync (Windows 版は themes 未同梱)
- `home.activation.weztermFonts`: UDEV Gothic NF も Windows 側 `~/.local/share/fonts` にデプロイ
- `home.file.".local/bin/install-ghostty-windows-fonts"`: Ghostty Windows 版は `C:\Windows\Fonts` のみを font scan 対象とするため (`src/font/SharedGridSet.zig` findWindowsFont)、ユーザーフォントをシステムフォントにコピーするワンショットヘルパーを追加。一時 `.ps1` 経由で UAC 昇格 PowerShell を実行し、WSL interop PATH に依存しないよう絶対パス (`/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe`) を使用

### hosts/ubuntu.nix
- `programs.ghostty.settings` を共有 settings 参照に変更（動作は変わらず、font 定義のみ Ubuntu Sans Mono → UDEV Gothic JPDOC/NF に追従）

### flake.nix / CLAUDE.md
- `wsl-gentoo` / `ubuntu` の modules に `./modules/ghostty` を追加
- モジュール構成とアーキテクチャ管理方針を更新

## Test plan

- [x] `nix flake check` が通ること
- [x] `nix build .#homeConfigurations."nanasess@wsl-gentoo".activationPackage` が通ること
- [x] `nix build .#homeConfigurations."nanasess@ubuntu".activationPackage` が通ること
- [x] 生成された `config.ghostty` の内容確認 (font-family/keybind/theme/command)
- [x] `home-manager switch --flake '.#nanasess@wsl-gentoo'` 後、`%LOCALAPPDATA%\ghostty\config.ghostty` と `themes/` が展開されていること
- [x] `install-ghostty-windows-fonts` でフォントが `C:\Windows\Fonts` にコピーされること
- [x] Windows の Ghostty を起動すると WSL Gentoo-systemd の zsh が立ち上がり、iTerm2 Solarized Light テーマが適用されること
- [x] `⏵⏵` 等の記号が豆腐にならず描画されること
- [ ] Ubuntu 側の Ghostty も変更後のフォント/テーマで起動すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Ghosttyターミナルエミュレータのサポートを追加。設定管理システムに統合されました。
  * WSL環境でのGhosttyfフォント自動インストール機能を実装。

* **ドキュメント**
  * Ghostty統合に関する設定ドキュメントを更新。Linux及びWindowsでの設定方法を明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->