### PR TITLE
feat(wsl-gentoo): Playwright 用 FHS 環境を追加

### DIFF
--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -36,6 +36,77 @@ let
     "dev-build/autoconf"
     "sys-libs/zlib"
   ];
+
+  # Playwright 用 FHS 環境
+  # プロジェクトごとに異なる @playwright/test バージョンに対応するため、
+  # browser バイナリは npm 側で `npx playwright install` させ、
+  # それが要求するシステムライブラリをこの FHS 環境で提供する
+  # 使い方: `playwright-fhs` で対話シェル / `playwright-fhs -c '<cmd>'` で単発実行
+  playwright-fhs = pkgs.buildFHSEnv {
+    name = "playwright-fhs";
+    targetPkgs = p: with p; [
+      # 共通
+      glib
+      nss
+      nspr
+      at-spi2-atk
+      at-spi2-core
+      cups
+      dbus
+      expat
+      libdrm
+      libxkbcommon
+      mesa
+      alsa-lib
+      pango
+      cairo
+      libgcc
+      libGL
+      fontconfig
+      freetype
+      cacert
+      nghttp2
+
+      # Chromium
+      xorg.libxshmfence
+
+      # GStreamer (WebKit 再生)
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-bad
+      gst_all_1.gst-libav
+
+      # WebKit / Firefox
+      icu
+      libxml2
+      libevent
+      libopus
+      flite
+      libjpeg_turbo
+      libmanette
+      enchant2
+      hyphen
+      woff2
+
+      # X11
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXrandr
+      xorg.libxcb
+      xorg.libXtst
+      xorg.libXScrnSaver
+      xorg.libXi
+      xorg.libXrender
+      xorg.libXcursor
+    ];
+    runScript = "bash";
+    profile = ''
+      export PATH="$HOME/.nix-profile/bin:$HOME/.local/bin:$PATH"
+    '';
+  };
 in
 {
   home.homeDirectory = "/home/nanasess";
@@ -44,6 +115,7 @@ in
 
   home.packages = with pkgs; [
     emacs30-gtk3
+    playwright-fhs
   ];
 
   home.sessionVariables = {


### PR DESCRIPTION
## 概要

apt-get 非対応の Gentoo 環境で Playwright を動かせるよう、`buildFHSEnv` で必要な共有ライブラリを提供する `playwright-fhs` コマンドを追加する。

## 背景

WSL Gentoo 上で `npx playwright install` 後にテスト実行すると、Playwright が下記のような apt パッケージを要求してエラーになる:

```
sudo apt-get install libgstreamer1.0-0 libicu74 libxml2 libevent-2.1-7t64 \
    libopus0 libgstreamer-plugins-base1.0-0 libwoff1 ...
```

Gentoo には apt が無いため、Nix で同等の依存を解決する必要があった。

## 設計判断

最初は `pkgs.playwright-driver.browsers` + `PLAYWRIGHT_BROWSERS_PATH` 環境変数で nixpkgs の patchelf 済み browser を使う案を検討したが、プロジェクトごとに `package.json` の `@playwright/test` バージョンが異なるため、グローバル固定では破綻する。

そこで `buildFHSEnv` で必要な system library を集めた FHS シェルを提供し、`npx playwright install` で各プロジェクトが取得した browser がその中で動く方式に変更した。

## 変更内容

- `hosts/wsl-gentoo.nix` の `let` ブロックに `playwright-fhs` 派生を追加
  - `targetPkgs`: chromium / firefox / webkit が要求する gstreamer / icu / woff2 / X11 / GL 等を網羅
  - `runScript = "bash"`: 対話シェルとしても `-c` で単発実行としても使える
  - `profile`: `~/.nix-profile/bin` と `~/.local/bin` を PATH に追加し、外側の環境を継承
- `home.packages` に `playwright-fhs` を追加

## 使い方

\`\`\`bash
cd ~/your-project
playwright-fhs                       # FHS シェルに入る
$ npm i -D @playwright/test
$ npx playwright install
$ npx playwright test
$ exit

# または単発で
playwright-fhs -c 'npx playwright test'
\`\`\`

## 動作確認

- [x] \`nix flake check\` が成功
- [x] \`nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage' --dry-run\` が成功
- [ ] \`home-manager switch\` 後、実プロジェクトで \`playwright-fhs -c 'npx playwright test'\` が動作

## 注意点

新しい Playwright バージョンが追加の system library を要求するようになった場合は、`targetPkgs` への追記で対応する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Playwright開発環境を新たに統合しました。Chromium、WebKit、Firefoxなどの複数のブラウザエンジンと、ブラウザ自動化テスト実行に必要なすべてのシステムライブラリをバンドルしています。追加の依存関係インストール不要で、ブラウザ自動化テストをすぐに実行できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->