### PR TITLE
docs(emacs): elpaca パッケージ更新手順を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,41 +139,15 @@ nix flake update home-manager
 `elpaca-lock-file` は `~/.config/home-manager/modules/emacs/elpaca.lock` を直接指しているため、
 `M-x elpaca-write-lock-file` で home-manager ソースに直接書き出される（手動コピー不要）。
 
-ロックファイルから復元された環境では全パッケージが detached HEAD になるため、
-`elpaca-pull-all` がそのままでは失敗する（[progfolio/elpaca#447](https://github.com/progfolio/elpaca/issues/447)）。
-以下のいずれかの方法で更新する。
+elpaca はロックファイルの `:ref` で各パッケージを特定コミットに固定するため、
+`~/.emacs.d/elpaca/sources/<pkg>/` は通常 detached HEAD 状態になっている。
+そのまま `elpaca-pull-all` を実行すると pull 先ブランチが特定できず失敗するので、
+事前にブランチを復元する必要がある（init.el で定義されている `elpaca-checkout-branches` を使う）。
 
-#### 方法 1: ロックファイルを一時無効化して更新（メンテナー推奨）
-
-```elisp
-;; init.el の elpaca-lock-file 設定を一時的にコメントアウト
-;; (setopt elpaca-lock-file ...)
-```
+#### 標準手順
 
 ```bash
-# 1. Emacs を再起動（ロックファイルなしで起動するため detached HEAD にならない）
-
-# 2. 全パッケージを更新
-M-x elpaca-pull-all
-
-# 3. 動作確認後、ロックファイルを書き出し
-M-x elpaca-write-lock-file
-
-# 4. init.el の elpaca-lock-file 設定を元に戻し、Emacs を再起動
-
-# 5. 変更をコミット
-cd ~/.config/home-manager
-git add modules/emacs/elpaca.lock
-git commit -m "chore(emacs): elpaca パッケージ更新"
-
-# 6. home-manager に反映
-home-manager switch --flake '.#nanasess@wsl-gentoo'
-```
-
-#### 方法 2: elpaca-checkout-branches で detached HEAD を解消して更新
-
-```bash
-# 1. 全パッケージのブランチを復元
+# 1. 全パッケージを default branch に戻す（detached HEAD 解消）
 M-x elpaca-checkout-branches
 
 # 2. 全パッケージを更新
@@ -191,11 +165,29 @@ git commit -m "chore(emacs): elpaca パッケージ更新"
 home-manager switch --flake '.#nanasess@wsl-gentoo'
 ```
 
+#### 既知の制約: 一部パッケージは手動 checkout が必要
+
+`elpaca-checkout-branches` は `git symbolic-ref refs/remotes/origin/HEAD` で default branch を判定するため、
+以下のような GNU ELPA mirror 由来でリモートに `origin/HEAD` シンボリックリンクがなく、
+かつ default が `main` / `master` でないパッケージでは復帰できない:
+
+- `csv-mode` (default branch: `externals/csv-mode`)
+- `queue` (default branch: `externals/queue`)
+
+これらは `elpaca-pull-all` のログでエラーになっていれば手動で checkout する:
+
+```bash
+cd ~/.emacs.d/elpaca/sources/csv-mode && git checkout externals/csv-mode
+cd ~/.emacs.d/elpaca/sources/queue    && git checkout externals/queue
+```
+
+その後あらためて `M-x elpaca-pull-all` を実行する。
+
 ### Nix + Emacs を一括更新
 
 ```bash
 nix flake update
-# Emacs で M-x elpaca-pull-all → M-x elpaca-write-lock-file
+# Emacs で M-x elpaca-checkout-branches → M-x elpaca-pull-all → M-x elpaca-write-lock-file
 home-manager switch --flake '.#nanasess@wsl-gentoo'
 git add flake.lock modules/emacs/elpaca.lock
 git commit -m "chore: nix flake update + elpaca パッケージ更新"

--- a/modules/emacs/elpaca.lock
+++ b/modules/emacs/elpaca.lock
@@ -76,7 +76,7 @@
                         "*-pkg.el"))
              :source "elpaca-menu-lock-file" :id cond-let :type git
              :protocol https :inherit t :depth treeless :ref
-             "8bf87d45e169ebc091103b2aae325aece3aa804d"))
+             "2cd0cd53e5a0deef15d204872f6feb391469f593"))
  (consult :source "elpaca-menu-lock-file" :recipe
           (:package "consult" :repo "minad/consult" :fetcher github
                     :files
@@ -90,7 +90,7 @@
                     :source "elpaca-menu-lock-file" :id consult :host
                     github :branch "main" :type git :protocol https
                     :inherit t :depth treeless :ref
-                    "20476c690ce3ecd45460011ce6b03fd58a642181"))
+                    "45fdad7b234141ea572267024c8f4b08dd2e1022"))
  (consult-dir :source "elpaca-menu-lock-file" :recipe
               (:package "consult-dir" :fetcher github :repo
                         "karthink/consult-dir" :files
@@ -209,7 +209,7 @@
                           :source "elpaca-menu-lock-file" :id
                           doom-modeline :type git :protocol https
                           :inherit t :depth treeless :ref
-                          "870b4b215fda881d29278d81bbab7f934a9bd8b3"))
+                          "871f91fad58aefa9e549cbff1929e0dd328021c7"))
  (doom-themes :source "elpaca-menu-lock-file" :recipe
               (:package "doom-themes" :fetcher github :repo
                         "doomemacs/themes" :files
@@ -244,7 +244,7 @@
    "elpaca-menu-lock-file" :recipe
    (:source nil :package "elpaca" :id elpaca :repo
             "https://github.com/progfolio/elpaca.git" :ref
-            "e9cb7eef2d8539e362d87f0489ab9eed8e8732c4" :depth 1
+            "9c9477d1154978d77b6eab9fcd68475826604188" :depth 1
             :inherit ignore :files
             (:defaults "elpaca-test.el" (:exclude "extensions"))
             :build (:not elpaca-activate) :type git :protocol https))
@@ -259,7 +259,7 @@
                                "Elpaca extensions" :id
                                elpaca-use-package :type git :protocol
                                https :inherit t :depth treeless :ref
-                               "e9cb7eef2d8539e362d87f0489ab9eed8e8732c4"))
+                               "9c9477d1154978d77b6eab9fcd68475826604188"))
  (embark :source "elpaca-menu-lock-file" :recipe
          (:package "embark" :repo "oantolin/embark" :fetcher github
                    :files ("embark.el" "embark-org.el" "embark.texi")
@@ -426,7 +426,7 @@
                    (:exclude "lisp/magit-section.el"))
                   :source "elpaca-menu-lock-file" :id magit :type git
                   :protocol https :inherit t :depth treeless :ref
-                  "4a1c6389e70b80152160e265738dd87e60fef496"))
+                  "6b10f7f6f90f3f2af69073d33568422dd38944df"))
  (magit-section :source "elpaca-menu-lock-file" :recipe
                 (:package "magit-section" :fetcher github :repo
                           "magit/magit" :files
@@ -436,7 +436,7 @@
                           :source "elpaca-menu-lock-file" :id
                           magit-section :type git :protocol https
                           :inherit t :depth treeless :ref
-                          "4a1c6389e70b80152160e265738dd87e60fef496"))
+                          "6b10f7f6f90f3f2af69073d33568422dd38944df"))
  (marginalia :source "elpaca-menu-lock-file" :recipe
              (:package "marginalia" :repo "minad/marginalia" :fetcher
                        github :files
@@ -451,7 +451,7 @@
                        :source "elpaca-menu-lock-file" :id marginalia
                        :host github :branch "main" :type git :protocol
                        https :inherit t :depth treeless :ref
-                       "51a79bb82355d0ce0ee677151f041a3aba8cbfca"))
+                       "4a0628dfdf944a5d307d31d2a514825cc5386986"))
  (markdown-mode :source "elpaca-menu-lock-file" :recipe
                 (:package "markdown-mode" :fetcher github :repo
                           "jrblevin/markdown-mode" :files
@@ -467,7 +467,7 @@
                           :source "elpaca-menu-lock-file" :id
                           markdown-mode :type git :protocol https
                           :inherit t :depth treeless :ref
-                          "182640f79c3ed66f82f0419f130dffc173ee9464"))
+                          "1f72cefa6a4b759f90e335e4908725a721b17ad9"))
  (mcp :source "elpaca-menu-lock-file" :recipe
       (:package "mcp" :fetcher github :repo "lizqwerscott/mcp.el"
                 :files
@@ -525,7 +525,7 @@
                              :source "elpaca-menu-lock-file" :id
                              multiple-cursors :type git :protocol
                              https :inherit t :depth treeless :ref
-                             "6f984c6e1d5f144027d2b6eafb6b77744fb2f8d5"))
+                             "94b8b07a4bab87f803123723b68227565429dfa1"))
  (nerd-icons :source "elpaca-menu-lock-file" :recipe
              (:package "nerd-icons" :repo
                        "rainstormstudio/nerd-icons.el" :fetcher github
@@ -533,7 +533,7 @@
                        "elpaca-menu-lock-file" :id nerd-icons :host
                        github :branch "main" :type git :protocol https
                        :inherit t :depth treeless :ref
-                       "1db0b0b9203cf293b38ac278273efcfc3581a05f"))
+                       "ae1b85c487c2b0bb1efb8bc0edc23af74282eec2"))
  (nginx-mode :source "elpaca-menu-lock-file" :recipe
              (:package "nginx-mode" :fetcher github :repo
                        "ajc/nginx-mode" :files
@@ -554,8 +554,9 @@
                      :files
                      (:defaults
                       (:exclude "nix-company.el" "nix-mode-mmm.el"))
-                     :source "MELPA" :id nix-mode :type git :protocol
-                     https :inherit t :depth treeless :ref
+                     :source "elpaca-menu-lock-file" :id nix-mode
+                     :type git :protocol https :inherit t :depth
+                     treeless :ref
                      "719feb7868fb567ecfe5578f6119892c771ac5e5"))
  (nskk :source "elpaca-menu-lock-file" :recipe
        (:source "elpaca-menu-lock-file" :package "nskk" :id nskk :host
@@ -809,7 +810,7 @@
                            symbol-overlay :host github :type git
                            :protocol https :inherit t :depth treeless
                            :ref
-                           "6151f4279bd94b5960149596b202cdcb45cacec2"))
+                           "253b957f5082603708b469d02ae8c31c58292823"))
  (terminal-here :source "elpaca-menu-lock-file" :recipe
                 (:package "terminal-here" :repo
                           "davidshepherd7/terminal-here" :fetcher
@@ -858,7 +859,7 @@
                       :source "elpaca-menu-lock-file" :id transient
                       :type git :protocol https :inherit t :depth
                       treeless :ref
-                      "e4e5f2ab1701ccc19d25361f1c574da6d33ac080"))
+                      "1946a0e844e6eb7bf1d0cb3bbee169ecd45f8844"))
  (ultra-scroll :source "elpaca-menu-lock-file" :recipe
                (:package "ultra-scroll" :fetcher github :repo
                          "jdtsmith/ultra-scroll" :files
@@ -875,7 +876,7 @@
                          ultra-scroll :host github :branch "main"
                          :type git :protocol https :inherit t :depth
                          treeless :ref
-                         "0a9a26071ec33305cbc7a0f1dc7202702319d51f"))
+                         "6dfb3478e6ee1a6c1534c56235c55f9d0ad9dca4"))
  (undo-tree :source "elpaca-menu-lock-file" :recipe
             (:package "undo-tree" :repo "emacsmirror/undo-tree" :tar
                       "0.8.2" :host github :files
@@ -889,7 +890,7 @@
                     "elpaca-menu-lock-file" :id vertico :host github
                     :branch "main" :type git :protocol https :inherit
                     t :depth treeless :ref
-                    "f3c2033ba63880d6265cf1e1eb9e987792042fc4"))
+                    "e4338c5bae2c725be2940726be170bc034af3b6c"))
  (visual-regexp :source "elpaca-menu-lock-file" :recipe
                 (:package "visual-regexp" :repo
                           "benma/visual-regexp.el" :fetcher github
@@ -907,6 +908,22 @@
                           visual-regexp :type git :protocol https
                           :inherit t :depth treeless :ref
                           "48457d42a5e0fe10fa3a9c15854f1f127ade09b5"))
+ (wakatime-mode :source "elpaca-menu-lock-file" :recipe
+                (:package "wakatime-mode" :fetcher github :repo
+                          "wakatime/wakatime-mode" :files
+                          ("*.el" "*.el.in" "dir" "*.info" "*.texi"
+                           "*.texinfo" "doc/dir" "doc/*.info"
+                           "doc/*.texi" "doc/*.texinfo" "lisp/*.el"
+                           "docs/dir" "docs/*.info" "docs/*.texi"
+                           "docs/*.texinfo"
+                           (:exclude ".dir-locals.el" "test.el"
+                                     "tests.el" "*-test.el"
+                                     "*-tests.el" "LICENSE" "README*"
+                                     "*-pkg.el"))
+                          :source "elpaca-menu-lock-file" :id
+                          wakatime-mode :type git :protocol https
+                          :inherit t :depth treeless :ref
+                          "1c5b2254dd72f2ff504d6a6189a8c10be03a98d1"))
  (web-mode :source "elpaca-menu-lock-file" :recipe
            (:package "web-mode" :repo "nanasess/web-mode" :fetcher
                      github :files
@@ -941,7 +958,7 @@
                         :source "elpaca-menu-lock-file" :id
                         with-editor :type git :protocol https :inherit
                         t :depth treeless :ref
-                        "64211dcb815f2533ac3d2a7e56ff36ae804d8338"))
+                        "d05405dbac95c9ca808d1b02066135df762d7e23"))
  (yaml-mode :source "elpaca-menu-lock-file" :recipe
             (:package "yaml-mode" :repo "yoshiki/yaml-mode" :fetcher
                       github :files
@@ -955,4 +972,4 @@
                       :source "elpaca-menu-lock-file" :id yaml-mode
                       :type git :protocol https :inherit t :depth
                       treeless :ref
-                      "d91f878729312a6beed77e6637c60497c5786efa")))
+                      "96ef0201101a7cd591febd5886633154dae8834c")))


### PR DESCRIPTION
## 概要

README.md の「Emacs パッケージの更新 (elpaca)」セクションを、実際の挙動と一致するように書き直しました。あわせて `elpaca-pull-all` で更新できたパッケージのロックファイルを反映しています。

## 変更内容

### docs(emacs): elpaca パッケージ更新手順を修正

- **「方法 1: ロックファイル一時無効化」を削除**
  - `~/.emacs.d/init.el` は Nix store 上の読み取り専用シンボリックリンクで、ユーザーが直接コメントアウトできない
  - また、ロックファイルを無効化しても、すでに detached HEAD になっている repo は detached のままで `elpaca-pull-all` の失敗は解消しない（detached の原因は起動時のロック復元ではなく、elpaca が `:ref` で特定コミットに固定する仕様）
- **「方法 2: elpaca-checkout-branches」を標準手順に昇格**
- **「既知の制約」セクションを追加**
  - `origin/HEAD` シンボリックリンクが未設定で、かつ default branch が `main` / `master` でないパッケージ（GNU ELPA mirror 由来の `csv-mode`, `queue` など）は `elpaca-checkout-branches` で復帰できない
  - 該当パッケージ用の手動 checkout コマンドを併記
- **「Nix + Emacs を一括更新」**: `M-x elpaca-checkout-branches` を手順に追加
- 誤誘導になっていた [progfolio/elpaca#447](https://github.com/progfolio/elpaca/issues/447) への参照を削除

### chore(emacs): elpaca パッケージを部分更新

`elpaca-pull-all` で更新に成功した 18 パッケージの `:ref` を反映:

| パッケージ |
|----------|
| cond-let |
| consult |
| doom-modeline |
| elpaca |
| elpaca-use-package |
| magit |
| magit-section |
| marginalia |
| markdown-mode |
| multiple-cursors |
| nerd-icons |
| symbol-overlay |
| transient |
| ultra-scroll |
| vertico |
| wakatime-mode |
| with-editor |
| yaml-mode |

未更新（detached HEAD で pull に失敗）:

- `csv-mode`, `queue` — `origin/HEAD` 未設定 + 非標準 default branch のため `elpaca-checkout-branches` で復帰できない（既知の制約）
- `popwin`, `prettier-emacs`, `web-mode` — `elpaca-checkout-branches` で復帰可能だが今回は未実行のため次回まわし

## Test plan

- [ ] README をレンダリングしてセクション構造を目視確認
- [ ] 標準手順に従って実際に `elpaca-checkout-branches` → `elpaca-pull-all` → `elpaca-write-lock-file` が通ることを確認
- [ ] csv-mode / queue が手動 checkout 後に pull できることを確認
- [ ] `home-manager switch` 後の Emacs 起動でロック復元が正常に動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)