### PR TITLE
feat(portage): gcc-15 をバイナリパッケージで取得できるようにする

### DIFF
--- a/modules/portage.nix
+++ b/modules/portage.nix
@@ -129,4 +129,9 @@
   xdg.configFile."portage/package.use/postgresql".text = ''
     dev-db/postgresql -systemd -xml
   '';
+
+  # Gentoo 公式 binhost のバイナリと USE を一致させ、gcc をソースビルドせずに済ませる
+  xdg.configFile."portage/package.use/gcc".text = ''
+    sys-devel/gcc lto pgo
+  '';
 }


### PR DESCRIPTION
## Summary

- `sys-devel/gcc` に `lto pgo` USE フラグを追加
- Gentoo 公式 binhost のバイナリ (`lto pgo` 有効) と USE を一致させ、`--binpkg-respect-use=y` でバイナリが弾かれないようにする
- gcc のソースビルド (PGO 込みで通常 1〜2 時間) を回避

## 背景

`emerge --update --deep --newuse @world` 実行時に以下のメッセージが出て、gcc がソースビルドにフォールバックしていた:

```
!!! The following binary packages have been ignored due to non matching USE:
    =sys-devel/gcc-15.2.1_p20260501 lto pgo
```

`emerge --info sys-devel/gcc` を確認すると、ローカルでは `-lto -pgo` (無効) になっており、binhost のバイナリ (有効) と一致せず弾かれていた。

## Changes

- `modules/portage.nix` に `xdg.configFile."portage/package.use/gcc"` を追加
  - 内容: `sys-devel/gcc lto pgo`
  - `/etc/portage/package.use` 自体がディレクトリへのシンボリックリンクのため、追加 root 操作は不要

## 影響範囲

| 項目 | 影響 |
|------|------|
| gcc の ABI / 出力 | 変化なし (gcc 自身の最適化フラグのみ) |
| gcc が生成するコード | 変化なし (ユーザーの CFLAGS は別物) |
| gcc 自体の実行性能 | LTO/PGO 最適化分だけ向上 |
| 他パッケージのリビルド | 不要 |
| ビルド時間 | binhost からダウンロードのみで完結 |

## Test plan

- [x] `nix flake check` が通ること
- [x] `home-manager switch --flake '.#nanasess@wsl-gentoo'` が成功すること
- [x] `/etc/portage/package.use/gcc` 経由で USE フラグが反映されていること
- [x] `emerge -p --update --deep --newuse @world` で gcc が `[binary U ~] ... USE="lto* pgo*"` として表示されること
- [x] `sudo emerge --update --deep --with-bdeps=y --newuse @world` が gcc をバイナリで取得して完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **設定**
  * GCC コンパイラの最適化フラグを更新しました。LTO（Link Time Optimization）と PGO（Profile-Guided Optimization）を有効にすることで、Gentoo 公式バイナリホストのバイナリとの互換性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->