### PR TITLE
fix(1password): Ubuntu では apt 版を使うよう変更

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -8,7 +8,6 @@
     builtins.elem (lib.getName pkg) [
       "terraform"
       "1password-cli"
-      "1password"
     ];
 
   programs.home-manager.enable = true;
@@ -64,8 +63,6 @@
     udev-gothic-nf
   ]
   ++ lib.optionals stdenv.isLinux [
-    _1password-cli
-    _1password-gui
     wl-clipboard
     xrandr
     libnotify

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -44,6 +44,9 @@ in
 
   home.packages = with pkgs; [
     emacs30-gtk3
+    # Windows 側の op.exe ではなく Linux 側で動かす必要がある
+    # `op run` 用 (~/.local/bin/op シム参照)
+    _1password-cli
   ];
 
   home.sessionVariables = {


### PR DESCRIPTION
## 概要

Ubuntu 環境で `op signin` がデスクトップアプリと通信できない問題を修正。

```
[ERROR] connecting to desktop app: read: connection reset, ...
[1P:op-ipc/src/ipc/unix.rs:412] peer was not in the correct application group, rejecting remote
PipeAuthError(NoCreds)
```

## 原因

1Password デスクトップアプリは IPC ソケットで `SO_PEERCRED` を用い、接続元プロセスのプライマリ GID が `onepassword-cli` であるかを検証する。`SO_PEERCRED` は補助グループを返さないため、ユーザーを `onepassword-cli` グループに追加するだけでは不十分で、`op` バイナリ自体に setgid `onepassword-cli` が必要。

公式 `.deb` の `op` には mode 2755 で setgid が付与されているが、Nix の `op` は `/nix/store` 配下（read-only）のため setgid を付けられない。NixOS 以外の Linux + Nix `_1password-cli` で発生する既知の問題。

## 変更内容

- `home.nix`
  - Linux optionals から `_1password-cli` / `_1password-gui` を削除
  - `allowUnfreePredicate` から `"1password"` を削除（`_1password-gui` を使う host が無くなったため）
- `hosts/wsl-gentoo.nix`
  - `_1password-cli` を `home.packages` に追加（`~/.local/bin/op` シムが `op run` でのみ Linux 版 op を呼ぶため）

## 各ホストの 1Password 構成

| ホスト | GUI | CLI (op) | op-ssh-sign |
|---|---|---|---|
| Ubuntu | apt `1password` | apt `1password-cli` (setgid 付き) | `/opt/1Password/op-ssh-sign` |
| WSL Gentoo | Windows 側 (WinGet) | Windows 側 op.exe + `op run` で Nix `_1password-cli` | Windows 側 `op-ssh-sign.exe` |
| macOS | Homebrew cask | Homebrew | `/Applications/1Password.app/...` |

## Ubuntu での適用手順

```bash
pkill -f 1password
home-manager switch --flake '.#nanasess@ubuntu'
sudo apt install 1password 1password-cli
# 1Password を起動し Settings > Developer > Integrate with 1Password CLI を ON
eval $(op signin)
```

## Test plan

- [x] `nix flake check` が通ること
- [x] `nix build '.#homeConfigurations."nanasess@ubuntu".activationPackage'` が成功すること
- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` が成功すること（CI で検証）
- [x] Ubuntu で apt 版に切替後 `op signin` が成功すること（実機検証済み）
- [ ] WSL Gentoo で `op run` が引き続き動作すること（次回 switch 時に確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * パッケージ構成を環境別に最適化しました。WSL Gentoo環境に1passwordコマンドラインツールのサポートを追加し、他の環境から関連パッケージの不要な参照を削除しました。システム構成のパッケージ許可設定も更新されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->