### PR TITLE
chore(zsh): 未使用の prompt gentoo 初期化を削除

### DIFF
--- a/modules/zsh/default.nix
+++ b/modules/zsh/default.nix
@@ -47,9 +47,8 @@
     };
 
     completionInit = ''
-      autoload -U compinit promptinit
+      autoload -U compinit
       compinit
-      promptinit; prompt gentoo
 
       eval "$(op completion zsh)"; compdef _op op
 


### PR DESCRIPTION
## Summary
- Powerlevel10k に上書きされて機能していなかった `prompt gentoo` 関連の初期化を削除
- `autoload` 対象から不要になった `promptinit` を除外

## Changes
- `modules/zsh/default.nix` の `completionInit` から以下を削除:
  - `autoload -U compinit promptinit` → `autoload -U compinit`
  - `promptinit; prompt gentoo` の行

## Test plan
- [ ] `nix flake check` が通ることを確認
- [ ] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` が成功することを確認
- [ ] `home-manager switch` 後、Powerlevel10k のプロンプトが従来通り表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)