### PR TITLE
fix(1password): wsl-gentoo に _1password-gui を復活

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -8,6 +8,7 @@
     builtins.elem (lib.getName pkg) [
       "terraform"
       "1password-cli"
+      "1password"
     ];
 
   programs.home-manager.enable = true;

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -47,6 +47,9 @@ in
     # Windows 側の op.exe ではなく Linux 側で動かす必要がある
     # `op run` 用 (~/.local/bin/op シム参照)
     _1password-cli
+    # ~/.config/zsh/.env.local (FIFO) への secrets 注入用
+    # Windows 側 1Password は Linux 側 FIFO に書き込めないため WSLg で Linux 版 GUI を起動する
+    _1password-gui
   ];
 
   home.sessionVariables = {


### PR DESCRIPTION
## Summary

- WSL Gentoo の `home.packages` に `_1password-gui` を追加し、PR #77 でのリグレッションを修正
- `home.nix` の `allowUnfreePredicate` に `1password` を追加 (unfree ライセンス許可)

## 背景

PR #77 (`fix/1password-ubuntu-apt`, 2026-05-09) で Ubuntu 公式 `.deb` 版に切り替える際、setgid 問題 (`PipeAuthError(NoCreds)`) を理由に `home.nix` から `_1password-cli` / `_1password-gui` をまとめて削除し、WSL Gentoo には `_1password-cli` のみ復活させていた。`_1password-gui` は復活させ忘れており、これが本 PR でのリグレッション修正にあたる。

## なぜ GUI が必須か

`~/.config/zsh/.env.local` は **named pipe (FIFO)** (`prw-------`) で、1Password の Environments 機能経由で GUI が secrets を流し込む受け口になっている。`modules/zsh/default.nix` の `envExtra` がこの FIFO を `cat` で読み出して環境変数として展開する設計。

Windows 側の 1Password 8 デスクトップアプリは Linux 側の FIFO に書き込めないため、**WSLg で動く Linux 版 GUI が必要**。

なお Gentoo には `onepassword-cli` グループ (gid 1002) が既に存在しているため、Ubuntu で発生した `PipeAuthError(NoCreds)` は (少なくとも実機検証時点では) 再現していない。

## 動作確認

- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` がエラー無く成功
- [x] `home-manager switch` 後、Nix の `1password-gui` が WSLg 上で起動
- [x] 新規 zsh セッションで `[WARNING] Could not load secrets` が出ず、`.env.local` (FIFO) 経由の secrets 注入が動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 1Password GUI アプリケーションをシステム環境に追加し、Linux 環境での利用を可能にしました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanasess/home-manager/pull/80)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->