### PR TITLE
feat(emacs): tree-sitter grammar 導入と各言語の *-ts-mode 切替

### DIFF
--- a/modules/emacs/default.nix
+++ b/modules/emacs/default.nix
@@ -1,9 +1,33 @@
 { config, pkgs, lib, ... }:
 
+let
+  # Emacs treesit が探すファイル名 (拡張子なし) → nixpkgs の grammar 派生物。
+  # キー名は各 major mode が `treesit-ready-p` などに渡す言語シンボルに合わせる
+  # (例: csharp-ts-mode は 'c-sharp を使うため、ファイル名も libtree-sitter-c-sharp.so にする)。
+  treesitGrammarMap = with pkgs.tree-sitter-grammars; {
+    typescript = tree-sitter-typescript;
+    tsx        = tree-sitter-tsx;
+    javascript = tree-sitter-javascript;
+    json       = tree-sitter-json;
+    css        = tree-sitter-css;
+    html       = tree-sitter-html;
+    yaml       = tree-sitter-yaml;
+    bash       = tree-sitter-bash;
+    c-sharp    = tree-sitter-c-sharp;
+  };
+
+  treesitGrammars = pkgs.runCommandLocal "treesit-grammars" { } ''
+    mkdir -p $out
+    ${lib.concatStrings (lib.mapAttrsToList (lang: grammar: ''
+      ln -s ${grammar}/parser $out/libtree-sitter-${lang}${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}
+    '') treesitGrammarMap)}
+  '';
+in
 {
   home.file.".emacs.d/init.el".source = ./init.el;
   home.file.".emacs.d/early-init.el".source = ./early-init.el;
   home.file.".emacs.d/site-lisp/eaw-console.el".source = ../locale-eaw/eaw-console.el;
+  home.file.".emacs.d/tree-sitter".source = treesitGrammars;
 
   home.activation.elpacaLockFile = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     install -Dm644 ${./elpaca.lock} ${config.home.homeDirectory}/.emacs.d/elpaca.lock

--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -341,7 +341,7 @@
   ;; treesit
   (setopt treesit-font-lock-level 4)
   (setopt treesit-language-source-alist
-          '((csharp . ("https://github.com/tree-sitter/tree-sitter-c-sharp.git"))))
+          '((c-sharp . ("https://github.com/tree-sitter/tree-sitter-c-sharp.git"))))
 
   ;; editor
   (setenv "EDITOR" "emacsclient"))
@@ -830,7 +830,6 @@
   :mode (("\\.\\(markdown\\|md\\)\\'" . gfm-mode))
   :custom
   (markdown-fontify-code-blocks-natively t)
-  (markdown-header-scaling t)
   (markdown-indent-on-enter 'indent-and-new-item)
   :bind (:map markdown-mode-map
          ("<S-tab>" . markdown-shifttab)))
@@ -881,19 +880,63 @@
                       (when (string-equal "tpl" (file-name-extension buffer-file-name))
                         (web-mode-set-engine "eccube")))))
 
+;;; JSON
+(use-package json-ts-mode
+  :ensure nil
+  :mode "\\.json\\'")
+
+;;; Shell scripts
+;; sh-mode に決まったあと bash-ts-mode へリマップする。bash-ts-mode 自体が
+;; shebang などから bash/sh でないと判断した場合は sh--redirect-bash-ts-mode
+;; advice で sh-mode に戻るため、zsh/csh 等は安全にフォールバックする。
+(use-package sh-script
+  :ensure nil
+  :init
+  (add-to-list 'major-mode-remap-alist '(sh-mode . bash-ts-mode)))
+
+;;; CSS
+(use-package css-mode
+  :ensure nil
+  :init
+  (add-to-list 'major-mode-remap-alist '(css-mode . css-ts-mode)))
+
+;;; JavaScript
+;; auto-mode-alist のデフォルトは `\.js[mx]?\' . javascript-mode' で、
+;; javascript-mode は js-mode の defalias。major-mode-remap はエイリアスを
+;; 解決しないため両方の名前でリマップする。
+(use-package js
+  :ensure nil
+  :init
+  (add-to-list 'major-mode-remap-alist '(javascript-mode . js-ts-mode))
+  (add-to-list 'major-mode-remap-alist '(js-mode . js-ts-mode)))
+
+;;; C#
+;; csharp-ts-mode は内部で言語シンボル 'c-sharp を使うため、grammar は
+;; libtree-sitter-c-sharp.so の名前で配置する必要がある (default.nix 参照)。
+(use-package csharp-mode
+  :ensure nil
+  :init
+  (add-to-list 'major-mode-remap-alist '(csharp-mode . csharp-ts-mode)))
+
 ;;; YAML
+;; ビルトインの yaml-ts-mode は treesit-simple-indent-rules が未実装で
+;; インデントが効かないため、手書きの indent ルールを持つ yaml-mode を優先する。
 (use-package yaml-mode
   :ensure t
-  :mode "\\.ya?ml\\'")
+  :mode "\\.ya?ml\\'"
+  :init
+  (setq auto-mode-alist
+        (rassq-delete-all 'yaml-ts-mode auto-mode-alist)))
 
 ;;; PHP
-(use-package php-ts-mode
-  :ensure nil
-  :mode "\\.\\(inc\\|php[s34]?\\)\\'"
-  :hook (php-ts-mode . (lambda ()
-                         (electric-indent-local-mode t)
-                         (electric-layout-mode t)
-                         (electric-pair-local-mode t))))
+(use-package php-mode
+  :ensure (:host github :repo "emacs-php/php-mode"
+                 :files ("lisp/*.el"))
+  :mode ("\\.\\(inc\\|php[s34]?\\|phtml\\)\\'" . php-mode)
+  :hook (php-mode . (lambda ()
+                      (electric-indent-local-mode t)
+                      (electric-layout-mode t)
+                      (electric-pair-local-mode t))))
 
 (use-package php-runtime
   :ensure (:host github :repo "emacs-php/php-runtime.el"))


### PR DESCRIPTION
## Summary
- `pkgs.tree-sitter-grammars` から 9 言語の parser を `~/.emacs.d/tree-sitter/` 配下に Nix で宣言的に配置
- `json` / `sh` / `css` / `js` / `csharp` を tree-sitter 版 major mode に切替
- `yaml-ts-mode` (インデント未実装) を避けて従来の `yaml-mode` を優先する設定を追加
- 既に phpstan 依存で読み込まれていた `php-mode` を明示的に登録し、`php-ts-mode` を撤去

## Changes

### `modules/emacs/default.nix`
- `treesitGrammarMap` を導入し、`pkgs.tree-sitter-grammars.tree-sitter-*` の `parser` を `~/.emacs.d/tree-sitter/libtree-sitter-<lang>${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}` の名前でシンボリックリンク
- 対象言語: typescript / tsx / javascript / json / css / html / yaml / bash / c-sharp
- ファイル名のキーは各 major mode が `treesit-ready-p` などに渡す言語シンボル名に合わせる (例: `csharp-ts-mode` は `'c-sharp` を使うため `libtree-sitter-c-sharp.so`)
- 拡張子は `pkgs.stdenv.hostPlatform.extensions.sharedLibrary` でプラットフォーム判定 (Linux: `.so`, macOS: `.dylib`)

### `modules/emacs/init.el`
- `treesit-language-source-alist` のキーを `csharp` → `c-sharp` に修正 (`csharp-ts-mode` の内部シンボルに揃える)
- `markdown-header-scaling t` を削除 (不要)
- 新規セクション追加:
  - **JSON**: `json-ts-mode` を `\.json\'` に明示登録 (autoload で auto-mode-alist に入らないため)
  - **Shell scripts**: `(sh-mode . bash-ts-mode)` を `major-mode-remap-alist` に追加。zsh/csh 等は `sh--redirect-bash-ts-mode` advice により `sh-mode` へフォールバック
  - **CSS**: `(css-mode . css-ts-mode)` を remap
  - **JavaScript**: `(javascript-mode . js-ts-mode)` と `(js-mode . js-ts-mode)` を remap (`major-mode-remap` は defalias を解決しないため両方必要)
  - **C#**: `(csharp-mode . csharp-ts-mode)` を remap
- **YAML**: `:init` で `auto-mode-alist` から `yaml-ts-mode` のエントリを除去し、手書きの indent ルールを持つ `yaml-mode` を優先 (Emacs 30 ビルトインの `yaml-ts-mode` は `treesit-simple-indent-rules` が未実装のため)
- **PHP**: `php-ts-mode` を撤去し `php-mode` を明示登録。`phpstan` パッケージの依存で php-mode が autoload 登録されてしまい `php-ts-mode` と競合していた問題に対処。対象拡張子に `phtml` も追加

## Test plan
- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` がローカルで成功する
- [x] `~/.emacs.d/tree-sitter/libtree-sitter-*.so` の 9 ファイルが配置されている
- [x] `.ts` / `.tsx` を開いて `treesit-font-lock-level 4` のハイライトが効く
- [x] `.json` を開くと `json-ts-mode` で開かれる
- [x] `.css` を開くと `css-ts-mode` で開かれる
- [x] `.js` を開くと `js-ts-mode` で開かれる
- [x] `.sh` を開くと `bash-ts-mode` で開かれ、zsh shebang の場合 `sh-mode` にフォールバックする
- [x] `.cs` / `M-x csharp-ts-mode` で `csharp-ts-mode` が起動する
- [x] `.yml` / `.yaml` を開くと `yaml-mode` で開かれ、TAB でインデントが動く
- [x] `.php` を開くと `php-mode` で開かれる
- [ ] CI (`nix flake check`) が通る
- [ ] `home-manager switch --flake '.#nanasess@ubuntu'` でも同様にビルドできる
- [ ] macOS でも `parser` を `.dylib` 拡張子で配置できる (ホスト未検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 複数のプログラミング言語でTree-sitterベースの構文強調表示に対応
  * JSON、シェルスクリプト、CSS、JavaScript、C#で新しい言語モードを有効化
  * Emacsのプログラミング言語設定を最適化

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanasess/home-manager/pull/81)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->