### PR TITLE
feat(emacs): dockerfile-ts-mode へ移行し未使用パッケージを整理

### DIFF
--- a/modules/emacs/default.nix
+++ b/modules/emacs/default.nix
@@ -14,6 +14,7 @@ let
     yaml       = tree-sitter-yaml;
     bash       = tree-sitter-bash;
     c-sharp    = tree-sitter-c-sharp;
+    dockerfile = tree-sitter-dockerfile;
   };
 
   treesitGrammars = pkgs.runCommandLocal "treesit-grammars" { } ''

--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -340,8 +340,6 @@
 
   ;; treesit
   (setopt treesit-font-lock-level 4)
-  (setopt treesit-language-source-alist
-          '((c-sharp . ("https://github.com/tree-sitter/tree-sitter-c-sharp.git"))))
 
   ;; editor
   (setenv "EDITOR" "emacsclient"))
@@ -556,11 +554,6 @@
 ;;;; ============================================================
 ;;;; Editing support
 ;;;; ============================================================
-(use-package terminal-here
-  :ensure (:host github :repo "davidshepherd7/terminal-here")
-  :custom
-  (terminal-here-mac-terminal-command 'iterm2))
-
 (use-package migemo
   :ensure t
   :if (file-exists-p (concat external-directory "migemo/dict/utf-8/migemo-dict"))
@@ -971,8 +964,13 @@
          (haskell-mode . turn-on-haskell-indentation)))
 
 ;;; Dockerfile
-(use-package dockerfile-mode
-  :ensure t)
+;; Emacs 29+ ビルトインの dockerfile-ts-mode を使う。grammar は Nix 側
+;; (default.nix) で libtree-sitter-dockerfile.so として配置済み。
+(use-package dockerfile-ts-mode
+  :ensure nil
+  :mode (("/Dockerfile\\(?:\\..*\\)?\\'" . dockerfile-ts-mode)
+         ("\\.[Dd]ockerfile\\'" . dockerfile-ts-mode)
+         ("/Containerfile\\(?:\\..*\\)?\\'" . dockerfile-ts-mode)))
 
 ;;; Terraform
 (use-package terraform-mode


### PR DESCRIPTION
## Summary
- `dockerfile-mode` (外部) を Emacs 29+ ビルトインの `dockerfile-ts-mode` に置換し、Nix 管理の grammar に揃える
- PR #81 で導入した tree-sitter grammar の後始末として `treesit-language-source-alist` を削除
- 未使用の `terminal-here` パッケージ宣言を削除

## Changes
### `modules/emacs/default.nix`
- `treesitGrammarMap` に `dockerfile = tree-sitter-dockerfile` を追加し、`~/.emacs.d/tree-sitter/libtree-sitter-dockerfile.*` を配置

### `modules/emacs/init.el`
- `dockerfile-mode` (外部) → `dockerfile-ts-mode` (組み込み) に置換し、`Dockerfile` / `*.dockerfile` / `Containerfile` を `:mode` で登録
- `treesit-language-source-alist` の `c-sharp` 設定を削除 (Nix 側で grammar を配置済みのため `treesit-install-language-grammar` 経路は不要。手動 install すると Nix 管理のシンボリックリンクが上書きされる懸念もある)
- 未使用の `terminal-here` use-package 宣言を削除 (キーバインドや呼び出しが無く実質未使用)

## Test plan
- [ ] `nix flake check` が通る
- [ ] `nix build '.#homeConfigurations.\"nanasess@wsl-gentoo\".activationPackage'` が成功する
- [ ] `home-manager switch` 後、`Dockerfile` を開いて `dockerfile-ts-mode` が起動することを確認
- [ ] csharp ファイルを開いて `csharp-ts-mode` が引き続き動作することを確認 (grammar の install 経路を外したことの影響確認)
- [ ] elpaca.lock の `dockerfile-mode` / `terminal-here` エントリは次回 `elpaca-update-menus` + ロック再生成で除去

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Dockerfile/Containerfile形式のコードファイルに対する統合構文ハイライト機能を追加

* **削除**
  * 外部ターミナルユーティリティパッケージの依存関係を削除

* **改善**
  * プログラミング言語別の設定を最適化・簡略化

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanasess/home-manager/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->