### PR TITLE
fix(1password): Nix から Gentoo portage (GURU) に移行

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -7,8 +7,6 @@
   nixpkgs.config.allowUnfreePredicate = pkg:
     builtins.elem (lib.getName pkg) [
       "terraform"
-      "1password-cli"
-      "1password"
     ];
 
   programs.home-manager.enable = true;

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -17,6 +17,14 @@ let
     "app-shells/zsh"
     "sys-apps/plocate"
 
+    # 1Password (GURU overlay)
+    # Nix /nix/store では setgid を付与できず Linux GUI と通信できないため、
+    # portage 経由で /usr/bin/op (setgid onepassword-cli) を導入する。
+    # GUI は ~/.config/zsh/.env.local (FIFO) への secrets 注入と
+    # SSH agent (~/.1password/agent.sock) を提供する。
+    "app-misc/1password-cli"
+    "gui-apps/1password"
+
     # mise PHP ビルド依存（asdf-php workflow.yml 参照）
     "dev-db/postgresql"
     "media-libs/gd"
@@ -44,12 +52,6 @@ in
 
   home.packages = with pkgs; [
     emacs30-gtk3
-    # Windows 側の op.exe ではなく Linux 側で動かす必要がある
-    # `op run` 用 (~/.local/bin/op シム参照)
-    _1password-cli
-    # ~/.config/zsh/.env.local (FIFO) への secrets 注入用
-    # Windows 側 1Password は Linux 側 FIFO に書き込めないため WSLg で Linux 版 GUI を起動する
-    _1password-gui
   ];
 
   home.sessionVariables = {
@@ -192,7 +194,11 @@ in
     text = ''
       #!/bin/bash
       OP_EXE="/mnt/c/Users/${config.home.username}/AppData/Local/Microsoft/WinGet/Links/op.exe"
-      OP_LINUX="${config.home.homeDirectory}/.nix-profile/bin/op"
+      # Gentoo portage の app-misc/1password-cli (GURU overlay) が
+      # setgid onepassword-cli 付きで /usr/bin/op を提供する。
+      # Nix /nix/store では setgid が付与できず Linux GUI と通信できないため、
+      # システム側 setgid バイナリを参照する。
+      OP_LINUX="/usr/bin/op"
 
       # op run は Linux のバイナリを実行するため、Windows の op.exe では動作しない
       if [ "$1" = "run" ] && [ -x "$OP_LINUX" ]; then

--- a/modules/portage.nix
+++ b/modules/portage.nix
@@ -98,6 +98,12 @@
     dev-python/pyfzf
     dev-python/click
     media-libs/mesa
+
+    # 1Password (GURU overlay)
+    app-misc/1password-cli ~amd64
+    gui-apps/1password ~amd64
+    acct-group/onepassword-cli ~amd64
+    acct-group/1password ~amd64
   '';
 
   xdg.configFile."portage/package.unmask".text = ''
@@ -106,9 +112,12 @@
     dev-python/click
   '';
 
-  # #48 移行済みパッケージを除外（terraform, 1password, op-cli-bin）
+  # #48 移行済みパッケージを除外（terraform, op-cli-bin）
+  # 1password 系は PR #85 で portage 管理に戻したためライセンス受諾を復活
   xdg.configFile."portage/package.license".text = ''
     www-client/google-chrome google-chrome
+    app-misc/1password-cli all-rights-reserved
+    gui-apps/1password all-rights-reserved
   '';
 
   xdg.configFile."portage/package.use/ffmpeg".text = ''


### PR DESCRIPTION
## 概要

WSL Gentoo で `eval \$(~/.nix-profile/bin/op signin)` が Linux 1password-gui と連携できない問題を修正。Nix `_1password-cli` を Gentoo portage の `app-misc/1password-cli` (GURU overlay) に置き換える。

## 背景・原因

PR #77 (`fix/1password-ubuntu-apt`) で特定した Ubuntu の問題と同一の根本原因。

> 1Password デスクトップアプリは IPC ソケットで \`SO_PEERCRED\` を用い、接続元プロセスのプライマリ GID が \`onepassword-cli\` であるかを検証する。\`SO_PEERCRED\` は補助グループを返さないため、ユーザーを \`onepassword-cli\` グループに追加するだけでは不十分で、\`op\` バイナリ自体に setgid \`onepassword-cli\` が必要。

Nix の `_1password-cli` は `/nix/store` 配下 (read-only) のため setgid を付けられない。

### PR #80 での認識誤り

> なお Gentoo には \`onepassword-cli\` グループ (gid 1002) が既に存在しているため、Ubuntu で発生した \`PipeAuthError(NoCreds)\` は (少なくとも実機検証時点では) 再現していない。

実際にはグループの存在を確認しただけで、(1) ユーザーがグループに所属していること、(2) op バイナリに setgid が付いていること、までは検証されておらず、実機で再現していた。

### 実機検証で確認した状態

| 項目 | 状態 |
|---|---|
| `~/.nix-profile/bin/op signin` | デスクトップ連携 NG — パスワード手動入力にフォールバック |
| `~/.nix-profile/bin/op` 権限 | `-r-xr-xr-x` (setgid 無し、`/nix/store` 配下) |
| ユーザー `nanasess` のグループ | nanasess, wheel, docker (**`onepassword-cli` に未所属**) |

## 解決策

GURU overlay の `app-misc/1password-cli` ebuild は setgid を正しく設定している:

\`\`\`bash
DEPEND=\"acct-group/onepassword-cli\"
src_install() {
    dobin op
    chgrp onepassword-cli \"\${D}/usr/bin/op\" || die \"Failed to set group of 1password CLI\"
    fperms g+s \"/usr/bin/op\"
}
\`\`\`

なお Gentoo 公式 portage の \`app-admin/op-cli-bin\` (William Hubbs メンテナ) は \`src_install() { dobin op }\` のみで setgid を設定していないため、こちらは採用しない。

## 変更内容

- **`home.nix`**: `allowUnfreePredicate` から `1password-cli` / `1password` を削除
- **`hosts/wsl-gentoo.nix`**:
  - `home.packages` から `_1password-cli` / `_1password-gui` を削除
  - `gentooPackages` に `app-misc/1password-cli`, `gui-apps/1password` (両方 GURU overlay) を追加し、`check-system-packages` のチェック対象に
  - `~/.local/bin/op` シムの `OP_LINUX` を `\${HOME}/.nix-profile/bin/op` → `/usr/bin/op` に変更
    - シム自体は廃止しない: `op run` は Linux op (Linux GUI 連携、setgid 経由)、それ以外は Windows op.exe (Windows Hello 連携) という分岐を維持

## 手動操作 (適用後に一度だけ)

\`\`\`bash
# GURU overlay は既に有効化済み
emerge --sync guru
emerge -av app-misc/1password-cli gui-apps/1password
sudo usermod -aG onepassword-cli nanasess
# 再ログイン後、1Password GUI を起動
# Settings > Developer > Integrate with 1Password CLI を ON
\`\`\`

## Test plan

- [x] `nix flake check` が通る
- [x] `nix build '.#homeConfigurations.\"nanasess@wsl-gentoo\".activationPackage'` が成功
- [x] `nix build '.#homeConfigurations.\"nanasess@ubuntu\".activationPackage'` が成功 (回帰なし)
- [x] 生成された `~/.local/bin/op` の `OP_LINUX` が `/usr/bin/op` を指す
- [ ] `home-manager switch` 後、`/usr/bin/op signin` で Linux 1password-gui との連携が成功する (実機検証は手動操作後)
- [ ] `op run --env-file=.env.tpl -- <command>` がシム経由で動作する (`op run` ブランチ)
- [ ] `op whoami` (シム経由) が Windows op.exe + Windows Hello で動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 1Passwordのパッケージ管理を再構成しました。パッケージの取得源を変更し、より効率的な構成に整理しました。
  * 1Passwordコマンドラインツールの参照先を更新しました。
  * ライセンス許可設定から不要な製品を削除しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanasess/home-manager/pull/85)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->