### PR TITLE
fix(portage): gnome-keyring 依存を撤去

### DIFF
--- a/modules/portage.nix
+++ b/modules/portage.nix
@@ -58,7 +58,10 @@
 
     ## default USE flags
     ## emerge --info | grep ^USE
-    USE="keyring wayland gnome"
+    ## NOTE: keyring USE は app-crypt/pinentry と dev-vcs/git の 2 つにしか効かず、
+    ##       gnome-keyring-daemon 依存と git-credential-libsecret を引き込む。
+    ##       WSL は 1Password 中心の運用で gnome-keyring が不要なため除去。
+    USE="wayland gnome"
 
     COMMON_FLAGS="-march=znver3 -O2 -pipe"
     CHOST="x86_64-pc-linux-gnu"
@@ -142,5 +145,11 @@
   # Gentoo 公式 binhost のバイナリと USE を一致させ、gcc をソースビルドせずに済ませる
   xdg.configFile."portage/package.use/gcc".text = ''
     sys-devel/gcc lto pgo
+  '';
+
+  # WSL は pinentry-tty を使うため GUI 版は不要。
+  # gtk USE が gnome-base/gnome-keyring を静的依存で引くため除外する。
+  xdg.configFile."portage/package.use/pinentry".text = ''
+    app-crypt/pinentry -gtk -qt6 -wayland
   '';
 }


### PR DESCRIPTION
## Summary

- WSL Gentoo で `git commit` のたびに gnome-keyring のロック解除パスワードを要求される問題を解消
- `make.conf` のグローバル USE から `keyring` を削除し、`pinentry` の GUI バリアント (gtk/qt6/wayland) を無効化することで、`gnome-base/gnome-keyring` とその関連スタックを一括撤去

## Background

調査の結果、以下の依存チェーンで gnome-keyring が引き込まれていた:

1. **`dev-vcs/git[keyring]`** → `git-credential-libsecret` → `app-crypt/libsecret` → `virtual/secret-service` → `gnome-base/gnome-keyring`
2. **`app-crypt/pinentry[gtk]`** → 静的依存で `gnome-base/gnome-keyring` を引く (ebuild の `gtk?` ブロック内)

`make.conf` の `USE="keyring wayland gnome"` がグローバルに `keyring` を ON にしていた。
`keyring` USE を持つパッケージは `app-crypt/pinentry` と `dev-vcs/git` の 2 つだけで、他に副作用はない。

`gpg-agent.conf` で `pinentry-program /usr/bin/pinentry-tty` を指定しているため、WSL で pinentry-gtk/qt6/wayland バリアントは使われていない。

## Changes

- `modules/portage.nix`:
  - `make.conf` の `USE` から `keyring` を削除 (`USE="wayland gnome"` に)
  - `package.use/pinentry` を新規追加し `app-crypt/pinentry -gtk -qt6 -wayland` を宣言

## Impact

depclean で以下 19 パッケージが連鎖削除対象になる:

**Secret Service スタック**
- `gnome-base/gnome-keyring`
- `app-crypt/libsecret`
- `app-crypt/gcr` (3.x / 4.x)
- `virtual/secret-service`

**pinentry GUI バリアントの連鎖**
- `gui-libs/gtk` (GTK4)
- `kde-frameworks/{kwindowsystem,kguiaddons,kf-env,extra-cmake-modules}`
- `dev-libs/plasma-wayland-protocols`
- `media-libs/{graphene,shaderc}`
- `x11-libs/libXinerama`, `app-text/iso-codes`
- `dev-python/{pygobject,pycairo}`

**ついで掃除**
- `sys-libs/pam_wrapper`
- `acct-group/1password` (PR #85 移行の孤立)

**影響なし** (別チャネルのため):
- 1Password SSH agent (`~/.1password/agent.sock`)
- `op-ssh-sign.exe` による commit 署名 (Windows 側)
- `gh` CLI (自前ストア)

## Test plan

- [x] `nix flake check` 通過
- [x] `emerge -pv --newuse dev-vcs/git app-crypt/pinentry` で USE 変更が `[binary]`/`[ebuild]` として認識される
- [x] `sudo emerge --newuse dev-vcs/git app-crypt/pinentry` でリビルド成功
  - `git` は binhost からバイナリ取得 (7.7 MiB)
  - `pinentry` は `-gtk -qt6 -wayland` の binhost バリアントが無いためソースビルド (599 KiB)
- [x] `sudo emerge -p --depclean` で 19 パッケージが削除対象として検出
- [x] `sudo emerge --depclean` 実行後、`gnome-keyring-daemon` プロセス消滅
- [x] `~/git-repos/enterprise.worktrees/pr-*` での `git commit` 動作確認、パスワードプロンプトが出ないこと

## Rollback

```bash
git revert <this-commit>
home-manager switch --flake '.#nanasess@wsl-gentoo'
sudo emerge --newuse dev-vcs/git app-crypt/pinentry gnome-base/gnome-keyring
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **設定改善**
  * WSL環境向けのパッケージ管理設定を最適化しました
  * GUIコンポーネントが不要な環境での設定を追加しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanasess/home-manager/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->