### PR TITLE
feat(home): less 用 LESSCOLORIZER に pygmentize を設定

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -133,7 +133,6 @@
     LESSCHARSET = "utf-8";
     LESS = "-R";
     LESSCOLORIZER = "pygmentize -O style=solarized-light";
-    JQ_COLORS = "1;36:0;33:0;33:0;36:0;32:1;39:1;39";
   };
 
   programs.ssh = {

--- a/home.nix
+++ b/home.nix
@@ -132,6 +132,7 @@
     PAGER = "less";
     LESSCHARSET = "utf-8";
     LESS = "-R";
+    LESSCOLORIZER = "pygmentize -O style=solarized-light";
     JQ_COLORS = "1;36:0;33:0;33:0;36:0;32:1;39:1;39";
   };
 


### PR DESCRIPTION
## Summary
- less でのソース表示をシンタックスハイライト付きにするため、`LESSCOLORIZER` 環境変数を追加
- `pygmentize -O style=solarized-light` を指定し、solarized-light テーマで色付け

## Changes
- `home.nix`: `home.sessionVariables` に `LESSCOLORIZER = "pygmentize -O style=solarized-light";` を追加

## Test plan
- [ ] `nix flake check` が成功する
- [ ] `home-manager switch --flake '.#nanasess@wsl-gentoo' --dry-run` が成功する
- [ ] `home-manager switch` 後、`less` でソースコードを開くとシンタックスハイライトが効く
- [ ] `pygmentize` が PATH にあること (system パッケージとして利用可能)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `less` コマンドで出力される内容に構文強調表示が有効化されました。`pygmentize` を利用してソースコードなどをより見やすく表示します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanasess/home-manager/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->