### PR TITLE
feat(zsh): COLORTERM=truecolor を未設定時に補完

### DIFF
--- a/modules/zsh/default.nix
+++ b/modules/zsh/default.nix
@@ -94,6 +94,14 @@
           TERM=xterm-256color
         fi
 
+        # COLORTERM
+        # Ghostty / WezTerm はネイティブに COLORTERM=truecolor をセットするが、
+        # WSL (wsl.exe 経由) で伝播が落ちるため未設定時のみ補完する。
+        # Claude Code の light テーマ等、24bit RGB を使う TUI の量子化を防ぐ。
+        if [ ! -n "''${COLORTERM}" ]; then
+          export COLORTERM=truecolor
+        fi
+
         # GPG
         if [ -t 0 ]; then
           export GPG_TTY=$(tty)

--- a/modules/zsh/default.nix
+++ b/modules/zsh/default.nix
@@ -90,7 +90,7 @@
         cdpath=($HOME)
 
         # TERM
-        if [ ! -n "''${TERM}" ]; then
+        if [[ -z "''${TERM}" ]]; then
           TERM=xterm-256color
         fi
 
@@ -98,7 +98,7 @@
         # Ghostty / WezTerm はネイティブに COLORTERM=truecolor をセットするが、
         # WSL (wsl.exe 経由) で伝播が落ちるため未設定時のみ補完する。
         # Claude Code の light テーマ等、24bit RGB を使う TUI の量子化を防ぐ。
-        if [ ! -n "''${COLORTERM}" ]; then
+        if [[ -z "''${COLORTERM}" ]]; then
           export COLORTERM=truecolor
         fi
 


### PR DESCRIPTION
## Summary

- WSL (`wsl.exe` 経由) では Ghostty / WezTerm がネイティブに設定する `COLORTERM=truecolor` の伝播が落ち、`COLORTERM` が空になる。
- その結果、Claude Code の `light` テーマ等、24bit RGB を使う TUI が 256 色に量子化され、diff の赤/緑や淡いグレー階調がくすむ。
- 既存の `TERM` フォールバックと同じ「未設定時のみ補完」idiom で `COLORTERM=truecolor` を export し、量子化を防ぐ。

## Changes

- `modules/zsh/default.nix`: `TERM` フォールバック直後に `COLORTERM` 補完ブロックを追加。`COLORTERM` が未設定のときだけ `truecolor` を export し、ネイティブに別値をセットする端末は上書きしない。

## Test plan

- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` 成功
- [x] 生成された `.zshrc` に補完ブロックが出力されることを確認
- [x] `home-manager switch` 後、新規シェルで `echo $COLORTERM` が `truecolor` を返す
- [x] Claude Code `light` テーマで diff の色階調が滑らかになることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ターミナルのカラーモード設定が未設定の場合にのみ適用されるようになりました。既存のユーザー設定が上書きされることなく、より正しく動作するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->