### PR TITLE
feat(zsh): git-worktree-manager のシェル統合を追加

### DIFF
--- a/modules/zsh/default.nix
+++ b/modules/zsh/default.nix
@@ -134,6 +134,10 @@
         # rbenv
         if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi
 
+        # git-worktree-manager シェル統合 (switch/create/checkout 後の自動 cd)
+        # https://github.com/nanasess/git-worktree-manager/pull/24
+        if command -v worktree > /dev/null; then eval "$(worktree shell-init)"; fi
+
         # misc
         export BAT_THEME=ansi-light
         export WEBKIT_FORCE_SANDBOX=0


### PR DESCRIPTION
## Summary

- `modules/zsh/default.nix` の `initContent` に `eval "$(worktree shell-init)"` を追加し、[git-worktree-manager](https://github.com/nanasess/git-worktree-manager) のシェル統合を有効化する
- これにより `worktree switch`/`create`/`checkout` 後の自動 cd・`switch -` トグルが利用可能になる (worktrunk 方式)
- 参照: https://github.com/nanasess/git-worktree-manager/pull/24

## Changes

- rbenv 初期化の直後 (PATH 設定後) に以下を追記:
  ```sh
  if command -v worktree > /dev/null; then eval "$(worktree shell-init)"; fi
  ```
- `command -v worktree` でガードし、`worktree` 未インストール環境 (macOS/Ubuntu の CI build matrix 等) でもシェル起動が壊れないようにした
- 子プロセスは親シェルの CWD を変更できないため、シェル関数で `cd` を行う `shell-init` 方式が必要

## Test plan

- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` 成功
- [x] 生成された `.zshrc` に `eval "$(worktree shell-init)"` が出力されることを確認
- [ ] `home-manager switch` 適用後、新規シェルで `worktree switch` の自動 cd を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)