### PR TITLE
fix(emacs): variable-pitch/fixed-pitch を静的フォントに固定

### DIFF
--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -129,14 +129,22 @@
 ;; GNU/Linux (WSL2, Ubuntu)
 ;; JPDOC をプライマリフォントに使用 (East Asian Ambiguous 文字が全角グリフ)
 (when (eq system-type 'gnu/linux)
+  ;; variable-pitch / fixed-pitch も静的フォントに固定する。
+  ;; generic "Sans Serif" は可変フォント NotoSans[wdth,wght].ttf に解決されるが、
+  ;; Emacs の ftcrhb バックエンドは可変フォントを realize できず豆腐になるため
+  ;; (about-emacs 等の variable-pitch 表示が崩れる)、静的フォントを明示する。
   (defun my/set-font-linux (frame)
     "Set font for FRAME when it is a graphic display."
     (when (display-graphic-p frame)
-      (set-face-attribute 'default frame :family "UDEV Gothic JPDOC" :height 120)))
+      (set-face-attribute 'default frame :family "UDEV Gothic JPDOC" :height 120)
+      (set-face-attribute 'variable-pitch frame :family "Noto Sans CJK JP")
+      (set-face-attribute 'fixed-pitch frame :family "UDEV Gothic JPDOC")))
   (if (daemonp)
       (add-hook 'after-make-frame-functions #'my/set-font-linux)
     (when (display-graphic-p)
-      (set-face-attribute 'default nil :family "UDEV Gothic JPDOC" :height 120))))
+      (set-face-attribute 'default nil :family "UDEV Gothic JPDOC" :height 120)
+      (set-face-attribute 'variable-pitch nil :family "Noto Sans CJK JP")
+      (set-face-attribute 'fixed-pitch nil :family "UDEV Gothic JPDOC"))))
 
 ;; server
 (when (display-graphic-p)


### PR DESCRIPTION
## Summary

`M-x about-emacs` で `variable-pitch` フェイスの文字（ASCII の `e` を含む）が豆腐（`display: no font available`）になる問題を修正する。

## 原因

- `variable-pitch` フェイスは generic family `"Sans Serif"` を使用する
- これが fontconfig 経由で可変フォント `~/.nix-profile/share/fonts/noto/NotoSans[wdth,wght].ttf` に解決される
- Emacs の `ftcrhb` (FreeType + Cairo + HarfBuzz) バックエンドは可変フォントを realize できず、`find-font` では見つかるのに `font-at` が nil を返して豆腐になる
- `default` フェイスは `UDEV Gothic JPDOC`（静的TTF）に固定されているため影響を受けていなかった

実フレームでの realize 検証結果:

| フォント | 種別 | realize |
|---|---|---|
| Noto Sans CJK JP | 静的 .ttc | ✅ OK |
| Ubuntu Sans | 静的 | ✅ OK |
| DejaVu Sans | 静的 | ✅ OK |
| Noto Sans | 可変フォント | ❌ TOFU |

## Changes

- `modules/emacs/init.el` の Linux 用フォント設定で `variable-pitch` / `fixed-pitch` も静的フォントに明示指定
  - `variable-pitch` → `Noto Sans CJK JP`（日本語グリフを含む静的サンセリフ）
  - `fixed-pitch` → `UDEV Gothic JPDOC`（default と統一）
- daemon フック (`my/set-font-linux`) 側・非 daemon 側の両方に追加
- 理由を説明するコメントを併記

## Test plan

- [x] 動作中の daemon に同設定を適用し `M-x about-emacs` で `variable-pitch` の文字（`e`, `s`, `E`, `a`）がすべて realize（font-at が non-nil）になることを確認
- [ ] `home-manager switch --flake '.#nanasess@ubuntu'` 適用後、クリーンな状態でも豆腐が出ないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクター**
  * GNU/Linux (WSL2/Ubuntu) 環境でのフォント設定が改善されました。複数のフォント種別に対して異なるフォントを個別に割り当てられるようになり、より詳細なフォント制御が可能になりました。
  * フォント設定の実行ロジックがデーモンモードと非デーモンモードで最適化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->