### PR TITLE
feat(emacs): Ubuntu を pgtk に移行しフォント構成を整理

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -65,10 +65,16 @@
     skktools
 
     # Fonts
-    noto-fonts
+    # noto-fonts (字形本体) はホスト側で管理する。Nix の noto-fonts は可変フォント版
+    # (NotoSans[wdth,wght].ttf) で、Linux の Emacs ftcrhb バックエンドが realize できず
+    # 各スクリプトが豆腐になるため。Ubuntu は OS の静的 Noto (272本) に委譲し、
+    # noto-fonts を入れない。WSL Gentoo / macOS は各ホストで追加する。
     noto-fonts-color-emoji
     udev-gothic
     udev-gothic-nf
+    # nerd-icons が参照する "Symbols Nerd Font Mono" を提供する。
+    # 未導入だと doom-modeline 等のアイコン (U+F0000 台) が豆腐になる。
+    nerd-fonts.symbols-only
   ]
   ++ lib.optionals stdenv.isLinux [
     wl-clipboard

--- a/hosts/macos.nix
+++ b/hosts/macos.nix
@@ -13,6 +13,12 @@ in
 {
   home.homeDirectory = "/Users/nanasess";
 
+  # 字形本体の Noto。home.nix 共通から移動 (Ubuntu のみ OS 静的 Noto に委譲する方針)。
+  # macOS の Emacs は CoreText (ns) バックエンドのため可変フォントでも問題ない。
+  home.packages = with pkgs; [
+    noto-fonts
+  ];
+
   programs.git.signing.signer = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";
 
   home.file.".local/bin/check-system-packages" = {

--- a/hosts/ubuntu.nix
+++ b/hosts/ubuntu.nix
@@ -56,10 +56,16 @@ in
   };
 
   home.packages = with pkgs; [
-    emacs30
+    # Wayland セッションでは pgtk ビルドを使う。XWayland (X11) 経由を避けることで
+    # GTK の長年のバグ (X11 接続喪失時に daemon ごとクラッシュ / GNOME #85715) を
+    # 回避し、HiDPI スケーリングと IME 連携も Wayland ネイティブになる。
+    emacs30-pgtk
     walker
     elephant
     libqalculate
+    # GNOME のUIフォント設定 (gsettings: Adwaita Sans) の実体。未導入だと
+    # pgtk Emacs の GTK メニュー/ツールバー/タイトルバーが豆腐になる。
+    adwaita-fonts
   ];
 
   home.file.".local/bin/walker-wrapper" = {

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -52,6 +52,8 @@ in
 
   home.packages = with pkgs; [
     emacs30-gtk3
+    # 字形本体の Noto。home.nix 共通から移動 (Ubuntu のみ OS 静的 Noto に委譲する方針)。
+    noto-fonts
   ];
 
   home.sessionVariables = {


### PR DESCRIPTION
## Summary

Ubuntu の Emacs を `emacs30` (X11) から `emacs30-pgtk` へ移行し、pgtk 化に伴って顕在化したフォントの豆腐をまとめて解消する。

現在のセッションが Wayland (`XDG_SESSION_TYPE=wayland`) であるにもかかわらず、X11 ビルドの Emacs を XWayland 経由で動かしていた。pgtk 化により Wayland ネイティブ表示になり、GTK の X11 接続喪失時に daemon ごとクラッシュするバグ（[GNOME #85715](http://bugzilla.gnome.org/show_bug.cgi?id=85715)）を回避でき、HiDPI スケーリングと IME 連携も改善する。

## Changes

| ファイル | 変更 | 目的 |
|---|---|---|
| `hosts/ubuntu.nix` | `emacs30` → `emacs30-pgtk` | Wayland ネイティブ化 |
| `hosts/ubuntu.nix` | `adwaita-fonts` 追加 | GTK chrome（メニュー/ツールバー/タイトルバー）の豆腐解消 |
| `home.nix` | `nerd-fonts.symbols-only` 追加 | nerd-icons の豆腐解消 |
| `home.nix` | `noto-fonts`（可変版）を共通から除外 | variable-pitch / 各スクリプトの豆腐解消 |
| `hosts/wsl-gentoo.nix` | `noto-fonts` 追加 | 共通から移動（現状維持） |
| `hosts/macos.nix` | `home.packages` 新設 ＋ `noto-fonts` | 共通から移動（現状維持） |

## 豆腐の原因と対処

pgtk 化で表面化した3系統のフォント問題を切り分けて対処した:

1. **GTK メニュー/ツールバー/タイトルバー** — gsettings のUIフォント指定が `Adwaita Sans` なのに実体が未導入（Ubuntu 24.04 / GNOME 46）。pgtk は GTK chrome をネイティブ描画するため豆腐化。→ `adwaita-fonts`（静的、ファミリ名一致）を導入。
2. **nerd-icons（U+F0000 台）** — `nerd-icons-font-family` の `Symbols Nerd Font Mono` が未導入。X11 は `UDEV Gothic NF` へフォールバックして救えていたが pgtk は救えず豆腐化。→ `nerd-fonts.symbols-only` を導入。
3. **variable-pitch / 各スクリプト（Javanese 等）** — Nix の `noto-fonts` が可変フォント（`NotoSans[wdth,wght]`）で、Emacs `ftcrhb` バックエンドが realize 不可。→ Ubuntu は OS の静的 Noto（272本）に委譲し、Nix の `noto-fonts` を共通から各ホストへ移動。

## Test plan

- [x] `nix build` で全4ホスト構成（ubuntu / wsl-gentoo / macbook / macbook-aarch64）の評価が成功
- [x] `nix build .#homeConfigurations."nanasess@ubuntu".activationPackage` 成功
- [x] `home-manager switch` 適用後、実機 Ubuntu (pgtk) で以下を目視確認:
  - [x] GTK のメニュー/ツールバー/タイトルバーが正常表示
  - [x] nerd-icons（doom-modeline / backtrace のアイコン）が正常表示
  - [x] hello の各スクリプト・about-emacs の variable-pitch が正常表示
- [ ] WSL Gentoo / macOS は `noto-fonts` 移動による現状維持（別環境で switch 確認）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * システム全体でフォント設定を最適化し、各ホスト向けに適切なフォントパッケージを配置しました
  * UbuntuホストのEmacsをpgtkビルドに更新し、Waylandセッション対応を改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->