### PR TITLE
feat(emacs): WSL Gentoo を pgtk に移行

### DIFF
--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -51,7 +51,10 @@ in
   programs.git.signing.signer = "/mnt/c/Users/${config.home.username}/AppData/Local/Microsoft/WindowsApps/op-ssh-sign.exe";
 
   home.packages = with pkgs; [
-    emacs30-gtk3
+    # WSLg では Weston が Wayland コンポジタとして動作し、Wayland ネイティブアプリは
+    # XWayland を経由せず Weston に直接接続する。pgtk ビルドにすることで XWayland の
+    # レイヤを外し、GTK の X11 接続喪失クラッシュ (GNOME #85715) を原理的に回避する。
+    emacs30-pgtk
     # 字形本体の Noto。home.nix 共通から移動 (Ubuntu のみ OS 静的 Noto に委譲する方針)。
     noto-fonts
   ];


### PR DESCRIPTION
## Summary

WSL Gentoo の Emacs を `emacs30-gtk3` (X11) から `emacs30-pgtk` へ移行する。Ubuntu の pgtk 移行（#93）に続く対応。

[microsoft/wslg の README](https://github.com/microsoft/wslg/blob/main/README.md) より、WSLg は **Weston を Wayland コンポジタ**として動作させ、**Wayland ネイティブアプリは XWayland を経由せず Weston に直接接続**する。pgtk ビルドにすることで XWayland のレイヤを外せる。

```
pgtk Emacs ──直接──→ Weston (Wayland) ──RDP backend/VAIL──→ Windows
(従来: emacs30-gtk3 ── XWayland ── Weston ── ...)
```

## Changes

| ファイル | 変更 |
|---|---|
| `hosts/wsl-gentoo.nix` | `emacs30-gtk3` → `emacs30-pgtk` |

## メリット

- **XWayland のレイヤを外す**（Weston 直結）
- **GTK #85715（X11 接続喪失時の daemon クラッシュ）を原理的に回避**（X11 接続自体が無くなる）
- 転送は Weston の RDP backend だが VAIL（共有メモリ最適化）経由のため、ネットワーク RDP のようなボトルネックにはならない

## Test plan

- [x] `nix build .#homeConfigurations."nanasess@wsl-gentoo".activationPackage` 成功
- [x] WSL Gentoo 実機で `home-manager switch` 後に以下を確認:
  - [x] `echo $WAYLAND_DISPLAY` が `wayland-0` 等を返す（Weston に接続できる）
  - [x] Emacs 内で `(frame-parameter nil 'font-backend)` が `(ftcrhb)` のみ（`x` が付かない = XWayland 非経由）
  - [x] メニュー/ツールバー/タイトルバー・nerd-icons・各スクリプトのフォント表示

## 留意点

pgtk は GTK chrome（メニュー/ツールバー/タイトルバー）をネイティブ描画するため、Ubuntu (#93) と同様に環境依存のフォント豆腐が出る可能性があるが、WSL Gentoo では追加対応なしで正常表示を確認済み。

- GTK UI フォント（gsettings の指定フォントの実体）の有無 → 必要なら `adwaita-fonts` 等を追加（WSL Gentoo では不要だった）
- `nerd-fonts.symbols-only` は #93 で `home.nix` 共通に入っているため WSL Gentoo にも適用済み
- **日本語 IME**: WSLg の Weston は `text-input`(Wayland IME) のサポートが限定的だが、**SKK（Emacs 内蔵入力）を使用しているため text-input に依存せず問題なし**（確認済み）

## Wayland 恩恵の確認方法（任意）

pgtk の恩恵は「CPU スループットの高速化」ではなく、**入力レイテンシ低減 / HiDPI / tear-free 描画 / 安定性**に出る。Emacs 自体の処理速度（elisp・font-lock 等）は X11 でも pgtk でも同じなので、確認は描画パスと入力レイテンシに着目する。

| 恩恵 | 確認方法 |
|---|---|
| **A/B 比較（基本）** | 下記「比較用 X11 経路の一時起動」で XWayland 経由 ↔ Weston 直結を並べて比較 |
| **入力レイテンシ**（pgtk が最も効く・定量） | [typometer](https://github.com/pavelfatin/typometer) で「キー入力→文字表示」遅延を ms 計測し X11/pgtk 比較 |
| **描画/スクロール** | 大きなファイルを開き `(benchmark-run 100 (redisplay t))` や全画面スクロール時間を両ビルドで比較。`M-x profiler-start RET cpu RET` →高速スクロール→ `profiler-report` で redisplay/font 系の割合 |
| **HiDPI・滑らかさ** | フォント輪郭の鮮明さ、長いバッファの高速スクロール時のティアリング/カクつきを目視 |

### 比較用 X11 経路の一時起動

現用の daemon は触らず、`-Q`（素の設定）で別インスタンスを一時起動して比較する。

```bash
# 1) 現状: pgtk + Wayland backend = Weston 直結
GDK_BACKEND=wayland emacs -Q &

# 2) 同じ pgtk バイナリで GDK backend だけ X11 に = XWayland 経由を強制
#    バイナリが同一なので「XWayland 1層の有無」だけを純粋に比較できる
GDK_BACKEND=x11 emacs -Q &

# 3) 純 X11 (GTK3) ビルドを flake の pin した nixpkgs から一時起動
#    こちらは window-system=x / font-backend=(ftcrhb x) で X11 と明示判別できる
nix run --inputs-from . nixpkgs#emacs30-gtk3 -- -Q
```

- `-Q` で現用 daemon に影響しない素のインスタンスとして起動する。
- 経路の確認: XWayland 経由なら `xlsclients` の一覧に emacs が現れる（Weston 直結の Wayland ネイティブなら現れない）。
- 注意: 2) の pgtk バイナリは GDK backend を X11 にしても Emacs 内部では `window-system` が常に `pgtk` のまま。経路の判別は上記 `xlsclients` で行う。`font-backend` で X11/pgtk を見分けられるのは 3) の純 X11 ビルドのみ。

```elisp
;; 描画パスのコスト（両ビルドで比較）
(benchmark-run 100 (redisplay t))

;; 全画面スクロールの所要時間
(benchmark-run 1
  (save-excursion
    (goto-char (point-min))
    (while (not (eobp)) (scroll-up 1) (redisplay t))))
```

### 環境による見え方の差（重要）

- **Ubuntu ネイティブ Wayland** → コンポジタ(mutter)が直接描画するため、レイテンシ・HiDPI・tear-free の恩恵が素直に出る。測るならこちらが分かりやすい。
- **WSL Gentoo (WSLg)** → 最終段が Weston→RDP(VAIL) で X11/pgtk 共通の経路。XWayland 1層は外せても転送段が支配的なため**高速化は体感しにくい**。WSL での pgtk の主目的は #85715 回避と SKK 前提の安定動作と割り切るのが現実的。