### PR TITLE
feat(emacs): nskk の辞書を skkserv (yaskkserv2) に逃がし GC スパイクを解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ sudo ln -sfn ~/.config/portage/repos.conf /etc/portage/repos.conf
 sudo getuto
 ```
 
+### SKK 辞書サーバ (yaskkserv2) のセットアップ（WSL Gentoo のみ）
+
+Emacs (nskk) の辞書本体を skkserv (yaskkserv2) に逃がし、nskk が全辞書を起動時にトライ索引へ全件展開することで full GC が 20-50 秒かかる問題を回避します。サーバは `modules/yaskkserv2.nix` が **systemd ユーザーサービス**として管理します（`/etc` も sudo も OpenRC も不要、ユーザー権限で `~/.config/yaskkserv2/` を読む）。バイナリと配信辞書のみ sudo で用意します。
+
+```bash
+# 1. yaskkserv2 をインストール（SKK-JISYO.L も依存で入る）
+sudo emerge -av app-i18n/yaskkserv2
+
+# 2. 配信辞書を SKK-JISYO.all.utf8 からビルド（辞書更新時のみ再実行）
+sudo install -d /usr/lib/yaskkserv2
+sudo yaskkserv2_make_dictionary \
+  --dictionary-filename /usr/lib/yaskkserv2/all \
+  --utf8 "$HOME/OneDrive - Skirnir Inc/emacs/ddskk/SKK-JISYO.all.utf8"
+
+# 3. home-manager switch で設定生成 + ユーザーサービス起動
+home-manager switch --flake '.#nanasess@wsl-gentoo'
+
+# 4. 稼働確認
+systemctl --user status yaskkserv2
+
+# 5. 変換動作確認（UTF-8 ワイヤ。1/愛/相/... が返れば OK。nc 不要）
+python3 -c 'import socket; s=socket.create_connection(("127.0.0.1",1178),2); s.sendall("1あい ".encode()); print(s.recv(8192).decode("utf-8","replace"))'
+```
+
+設定 (`modules/yaskkserv2.nix`) を変更したら `home-manager switch` で自動反映されます（手動再起動が要る場合は `systemctl --user restart yaskkserv2`）。`listen-address = 0.0.0.0` なので WSL2 の localhostForwarding 経由で Windows からも `localhost:1178` で共有できます。
+
 ### システムパッケージの確認
 
 各ホストでシステムパッケージマネージャ（portage/apt/Homebrew）のパッケージが揃っているか確認できます。

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ systemctl --user status yaskkserv2
 python3 -c 'import socket; s=socket.create_connection(("127.0.0.1",1178),2); s.sendall("1あい ".encode()); print(s.recv(8192).decode("utf-8","replace"))'
 ```
 
-設定 (`modules/yaskkserv2.nix`) を変更したら `home-manager switch` で自動反映されます（手動再起動が要る場合は `systemctl --user restart yaskkserv2`）。`listen-address = 0.0.0.0` なので WSL2 の localhostForwarding 経由で Windows からも `localhost:1178` で共有できます。
+設定 (`modules/yaskkserv2.nix`) を変更したら `home-manager switch` で自動反映されます（手動再起動が要る場合は `systemctl --user restart yaskkserv2`）。`listen-address = 127.0.0.1`（LAN へ露出しない）ですが、WSL2 の localhostForwarding 経由で Windows からも `localhost:1178` で接続できます。
 
 ### システムパッケージの確認
 

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       homeConfigurations = {
         "nanasess@wsl-gentoo" = home-manager.lib.homeManagerConfiguration {
           pkgs = nixpkgs.legacyPackages.x86_64-linux;
-          modules = [ ./home.nix ./hosts/wsl-gentoo.nix ./modules/onedrive.nix ./modules/portage.nix ./modules/locale-eaw ./modules/emacs ./modules/zsh ./modules/ghostty ./modules/wakatime ];
+          modules = [ ./home.nix ./hosts/wsl-gentoo.nix ./modules/onedrive.nix ./modules/portage.nix ./modules/yaskkserv2.nix ./modules/locale-eaw ./modules/emacs ./modules/zsh ./modules/ghostty ./modules/wakatime ];
         };
         "nanasess@macbook" = home-manager.lib.homeManagerConfiguration {
           pkgs = nixpkgs.legacyPackages.x86_64-darwin;

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -19,7 +19,8 @@ let
 
     # SKK 辞書サーバ (skkserv)。Emacs nskk の辞書本体をこのサーバへ逃がし、
     # nskk のトライ索引 (~650MiB) が full GC を 20-50 秒占有する問題を解消する。
-    # RDEPEND の app-i18n/skk-jisyo で SKK-JISYO.L も入る。OpenRC で常駐。
+    # RDEPEND の app-i18n/skk-jisyo で SKK-JISYO.L も入る。
+    # 常駐は systemd ユーザーサービス (modules/yaskkserv2.nix) で管理。
     "app-i18n/yaskkserv2"
 
     # 1Password (GURU overlay)

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -17,6 +17,11 @@ let
     "app-shells/zsh"
     "sys-apps/plocate"
 
+    # SKK 辞書サーバ (skkserv)。Emacs nskk の辞書本体をこのサーバへ逃がし、
+    # nskk のトライ索引 (~650MiB) が full GC を 20-50 秒占有する問題を解消する。
+    # RDEPEND の app-i18n/skk-jisyo で SKK-JISYO.L も入る。OpenRC で常駐。
+    "app-i18n/yaskkserv2"
+
     # 1Password (GURU overlay)
     # Nix /nix/store では setgid を付与できず Linux GUI と通信できないため、
     # portage 経由で /usr/bin/op (setgid onepassword-cli) を導入する。

--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -201,8 +201,22 @@
          ("C-x C-j" . nskk-toggle-mode))
   :custom
   (nskk-dict-user-dictionary-file (concat external-directory "nskk/jisyo"))
-  (nskk-dict-system-dictionary-files
-   (list (concat external-directory "ddskk/SKK-JISYO.all.utf8")))
+  ;; 辞書本体は skkserv (yaskkserv2) に逃がし、Emacs ヒープには載せない。
+  ;; nskk は全システム辞書を起動時にトライ索引 (nskk--prolog-trie-indices) へ
+  ;; 全件展開するため、SKK-JISYO.all (50 万件) で索引が ~650MiB に膨張し、
+  ;; full GC が 20-50 秒かかっていた。system-dict を nil + ja-dic 無効にすると
+  ;; in-memory 辞書はユーザー辞書 (学習語) のみになりヒープが激減する。
+  ;; 変換は skkserv を第一ソースとして引く (nskk-henkan.el の optional-server-lookup)。
+  ;; サーバ未起動のホストではユーザー辞書のみに縮退する (接続は live-p で fast-fail)。
+  (nskk-dict-system-dictionary-files nil)
+  (nskk-dict-use-ja-dic nil)
+  (nskk-server-enable t)
+  (nskk-server-host "localhost")
+  (nskk-server-portnum 1178)
+  ;; yaskkserv2 を --midashi-utf8 で起動し、SKK-JISYO.all.utf8 (EUC-JP では
+  ;; 表現できない文字を含む) を UTF-8 でワイヤ送受信する。既定の euc-jp だと
+  ;; 文字化けするため utf-8 に合わせる (nskk-server.el の coding-system-for-read/write)。
+  (nskk-server-coding-system 'utf-8)
   (nskk-show-tooltip t)
   (nskk-use-color-cursor t)
   (nskk-converter-auto-start-henkan t)

--- a/modules/yaskkserv2.nix
+++ b/modules/yaskkserv2.nix
@@ -25,7 +25,9 @@
   xdg.configFile."yaskkserv2/yaskkserv2.conf".text = ''
     dictionary = /usr/lib/yaskkserv2/all
     port = 1178
-    listen-address = 0.0.0.0
+    # 127.0.0.1 に限定 (LAN へ露出しない)。WSL2 の localhostForwarding により
+    # Windows 側からも localhost:1178 で到達できる。
+    listen-address = 127.0.0.1
     max-connections = 16
     google-japanese-input = notfound
     google-suggest = enable
@@ -41,7 +43,7 @@
     Service = {
       # --midashi-utf8: SKK-JISYO.all.utf8 は EUC-JP 不可文字を含むため UTF-8 で
       # 統一し、nskk 側 nskk-server-coding-system 'utf-8 (init.el) と整合させる。
-      ExecStart = "/usr/bin/yaskkserv2 --no-daemonize --midashi-utf8 --config-filename ${config.home.homeDirectory}/.config/yaskkserv2/yaskkserv2.conf";
+      ExecStart = "/usr/bin/yaskkserv2 --no-daemonize --midashi-utf8 --config-filename ${config.xdg.configHome}/yaskkserv2/yaskkserv2.conf";
       Restart = "on-failure";
       RestartSec = 3;
     };

--- a/modules/yaskkserv2.nix
+++ b/modules/yaskkserv2.nix
@@ -1,0 +1,50 @@
+{ config, ... }:
+{
+  # yaskkserv2 (skkserv) を systemd ユーザーサービスとして宣言管理する。
+  # Emacs nskk の辞書本体をこのサーバへ逃がし、nskk が全辞書を起動時にトライ索引
+  # (nskk--prolog-trie-indices) へ全件展開して live ヒープが ~650MiB に膨れ、
+  # full GC が 20-50 秒かかる問題を解消する (init.el の nskk 設定参照)。
+  #
+  # systemd ユーザーサービスなので /etc 書き込みも sudo も OpenRC も不要。ユーザー
+  # 権限で動き ~/.config を直接読める。ebuild 同梱の system unit (User=nobody、
+  # /etc/yaskkserv2.conf を読む、--midashi-utf8 無し) は使わない (disabled のまま)。
+  #
+  # 事前準備 (sudo が要る部分。詳細は README.md「SKK 辞書サーバ」節):
+  #   sudo emerge -av app-i18n/yaskkserv2        # バイナリ + SKK-JISYO.L
+  #   sudo install -d /usr/lib/yaskkserv2        # 配信辞書を SKK-JISYO.all.utf8 から
+  #   sudo yaskkserv2_make_dictionary \          #   ビルド (辞書更新時のみ再実行)
+  #     --dictionary-filename /usr/lib/yaskkserv2/all \
+  #     --utf8 "$HOME/OneDrive - Skirnir Inc/emacs/ddskk/SKK-JISYO.all.utf8"
+  # その後 `home-manager switch` でサービスが起動する。
+
+  # サーバ設定。--config-filename でこのファイルを直接読ませる (/etc は経由しない)。
+  # google 連携を有効化。notfound = ローカル辞書で見つからない語のみ Google 日本語
+  # 入力 CGI へ問い合わせる。通信は HTTPS (google-use-http = disable のまま)。
+  # 注意: 変換キー (よみ) が Google に送信される。オフライン/プライバシー重視に
+  # 戻すなら google-japanese-input = disable / google-suggest = disable に。
+  xdg.configFile."yaskkserv2/yaskkserv2.conf".text = ''
+    dictionary = /usr/lib/yaskkserv2/all
+    port = 1178
+    listen-address = 0.0.0.0
+    max-connections = 16
+    google-japanese-input = notfound
+    google-suggest = enable
+    google-use-http = disable
+  '';
+
+  systemd.user.services.yaskkserv2 = {
+    Unit = {
+      Description = "Yet Another SKK server (yaskkserv2) for Emacs nskk";
+      Documentation = [ "https://github.com/wachikun/yaskkserv2" ];
+      After = [ "network.target" ];
+    };
+    Service = {
+      # --midashi-utf8: SKK-JISYO.all.utf8 は EUC-JP 不可文字を含むため UTF-8 で
+      # 統一し、nskk 側 nskk-server-coding-system 'utf-8 (init.el) と整合させる。
+      ExecStart = "/usr/bin/yaskkserv2 --no-daemonize --midashi-utf8 --config-filename ${config.home.homeDirectory}/.config/yaskkserv2/yaskkserv2.conf";
+      Restart = "on-failure";
+      RestartSec = 3;
+    };
+    Install.WantedBy = [ "default.target" ];
+  };
+}


### PR DESCRIPTION
## Summary

WSL Gentoo の Emacs で full GC が 20-50 秒かかる問題を解消する。

nskk (takeokunn/nskk.el) は ddskk と異なり、システム辞書を**起動時に全件トライ索引へ展開**する。SKK-JISYO.all (約50万件) で `nskk--prolog-trie-indices` が ~648MiB の live ヒープになり、毎回の full GC のマーク対象になっていた (`M-x memory-report` で確認)。ddskk は辞書をバッファのテキストのまま二分探索するためヒープに乗らず、この問題が無かった。

辞書本体を yaskkserv2 (skkserv) に逃がし、Emacs の in-memory 辞書をユーザー辞書 (学習語) のみにすることで解決した。

## Changes

- **modules/emacs/init.el**: nskk を skkserv 構成に変更
  - `nskk-dict-system-dictionary-files nil` + `nskk-dict-use-ja-dic nil` で in-memory 辞書をユーザー辞書のみに
  - `nskk-server-enable t` で skkserv を第一検索ソースに (検索パスは `nskk-server-live-p` で fast-fail するためサーバ落ちでも変換ごとに固まらない)
  - `nskk-server-coding-system 'utf-8` で yaskkserv2 の `--midashi-utf8` と整合 (SKK-JISYO.all.utf8 は EUC-JP 不可文字を含むため UTF-8 で統一)
- **modules/yaskkserv2.nix** (新規): yaskkserv2 を **systemd ユーザーサービス**として宣言管理
  - `/etc` 書き込み・sudo・OpenRC 不要 (ユーザー権限で `~/.config/yaskkserv2/` を `--config-filename` で読む)
  - ebuild 同梱の system unit は `User=nobody` で `~/.config` を読めず `--midashi-utf8` も付かないため使わない
  - Google 日本語入力連携 (notfound, HTTPS) を有効化
- **hosts/wsl-gentoo.nix**: `app-i18n/yaskkserv2` を gentooPackages に追加 (check-system-packages の差分検知用)
- **flake.nix**: wsl-gentoo の modules に `./modules/yaskkserv2.nix` を追加
- **README.md**: 「SKK 辞書サーバ (yaskkserv2) のセットアップ」節を追加

## 効果 (memory-report)

| 指標 | Before | After |
|---|--:|--:|
| Memory Used By Global Variables | 762 MiB | 8.7 MiB |
| Overall Object Memory Usage | 277 MiB | 32 MiB |
| `nskk--prolog-trie-indices` | 648 MiB | 81 KiB |
| `nskk--prolog-database` | 105 MiB | 102 KiB |

## Test plan

- [x] `nix build --dry-run` で wsl-gentoo の eval が通る
- [x] yaskkserv2 をユーザー権限起動し UTF-8 ワイヤで「あい」→ 愛/相/藍/... を確認
- [x] 辞書に無い「きょうのてんき」→ Google 経由で 今日の天気/... を確認
- [x] emacsclient で SKK 入力が問題なく動作
- [x] memory-report で `nskk--prolog-trie-indices` が 648MiB → 81KiB に激減
- [x] `home-manager switch` 後の systemd ユーザーサービス自動起動を実機で確認

## 初回セットアップ (WSL Gentoo)

`README.md`「SKK 辞書サーバ (yaskkserv2) のセットアップ」参照。`sudo emerge -av app-i18n/yaskkserv2` と配信辞書ビルドのみ sudo が必要、以降は `home-manager switch` で完結する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * SKK 辞書サーバ（yaskkserv2）の統合サポートを追加しました。システム辞書をサーバ側で管理することで、Emacs 起動時の全辞書展開による GC 遅延を回避できます。
  * yaskkserv2 をシステムサービスとして自動管理するモジュールを追加しました。

* **ドキュメント**
  * yaskkserv2 のセットアップ手順と運用ガイドを README に追加しました。

* **スタイル**
  * 設定ファイルの フォーマットを整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->