### PR TITLE
feat(emacs): lsp-bridge のモードライン表示を「橋」に戻す

### DIFF
--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -899,6 +899,9 @@
         (expand-file-name "~/.local/share/lsp-bridge/.venv/bin/python"))
   ;; PHP は phpactor を使用 (langserver/phpactor.json が同梱されている)
   (setq lsp-bridge-php-lsp-server "phpactor")
+  ;; モードライン表示は "橋" にする (PR #751 で defcustom 化された lighter)。
+  ;; commit ba34436 でデフォルトが " 橋" → " LSPB" に変わったが、好みで戻す。
+  (setq lsp-bridge-mode-lighter " 橋")
   ;; 対象モードを明示。csharp-ts-mode 等は LSP を入れていないので除外する。
   (setq lsp-bridge-default-mode-hooks
         '(php-ts-mode-hook
@@ -919,6 +922,19 @@
           ;; elisp symbol 同期 (lsp-bridge-elisp-symbols-update) で補完する。
           emacs-lisp-mode-hook))
   :config
+  ;; doom-modeline は minor-mode lighter を描画しない (doom-modeline-minor-modes nil) ため、
+  ;; lsp-bridge-mode-lighter を設定しても画面には出ない。実際に見えているのは
+  ;; mode-line-misc-info に積まれる lsp-bridge--mode-line-format の出力 ("lsp-bridge")。
+  ;; そこで misc-info 側も lighter (= "橋") で描画するよう差し替える。
+  ;; NOTE: これは upstream の内部関数を上書きする。lsp-bridge 更新時に
+  ;;       lsp-bridge--mode-line-format の定義が変わったら追従が必要。
+  (defun lsp-bridge--mode-line-format ()
+    "Compose the LSP-bridge's mode-line (lsp-bridge-mode-lighter を表示する版)."
+    (when lsp-bridge-server
+      (propertize (string-trim lsp-bridge-mode-lighter)
+                  'face (if (lsp-bridge-process-live-p)
+                            'lsp-bridge-alive-mode-line
+                          'lsp-bridge-kill-mode-line))))
   (global-lsp-bridge-mode))
 
 ;;;; ============================================================

--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -926,15 +926,20 @@
   ;; lsp-bridge-mode-lighter を設定しても画面には出ない。実際に見えているのは
   ;; mode-line-misc-info に積まれる lsp-bridge--mode-line-format の出力 ("lsp-bridge")。
   ;; そこで misc-info 側も lighter (= "橋") で描画するよう差し替える。
-  ;; NOTE: これは upstream の内部関数を上書きする。lsp-bridge 更新時に
-  ;;       lsp-bridge--mode-line-format の定義が変わったら追従が必要。
-  (defun lsp-bridge--mode-line-format ()
+  ;; defun での直接再定義ではなく advice-add :override を使う。再定義は lsp-bridge
+  ;; 再読み込み時に upstream 定義へ巻き戻るが、advice は再定義をまたいで残る。
+  ;; stringp ガードは redisplay 毎に走るため、非文字列設定でも string-trim が
+  ;; 落ちないようにする保険 (boundp は同一ファイル由来で常に bound のため省略)。
+  ;; NOTE: upstream の lsp-bridge--mode-line-format 定義が変わったら追従が必要。
+  (defun my/lsp-bridge--mode-line-format ()
     "Compose the LSP-bridge's mode-line (lsp-bridge-mode-lighter を表示する版)."
-    (when lsp-bridge-server
+    (when (and lsp-bridge-server
+               (stringp lsp-bridge-mode-lighter))
       (propertize (string-trim lsp-bridge-mode-lighter)
                   'face (if (lsp-bridge-process-live-p)
                             'lsp-bridge-alive-mode-line
                           'lsp-bridge-kill-mode-line))))
+  (advice-add 'lsp-bridge--mode-line-format :override #'my/lsp-bridge--mode-line-format)
   (global-lsp-bridge-mode))
 
 ;;;; ============================================================


### PR DESCRIPTION
## Summary

- lsp-bridge upstream の commit `ba34436` でモードライン lighter のデフォルトが `" 橋"` → `" LSPB"` に変更されたため、好みの「橋」表示に戻す
- PR #751 ([manateelazycat/lsp-bridge#751](https://github.com/manateelazycat/lsp-bridge/pull/751)) で `lsp-bridge-mode-lighter` が defcustom 化されたのを利用

## Changes

- `modules/emacs/init.el` (lsp-bridge `use-package`):
  - `:init` で `(setq lsp-bridge-mode-lighter " 橋")` を設定
  - `:config` で `lsp-bridge--mode-line-format` を上書き
    - doom-modeline は minor-mode lighter を描画しない (`doom-modeline-minor-modes` が nil) ため、lighter 設定だけでは画面に出ない
    - 実際に見えているのは `mode-line-misc-info` に積まれる `lsp-bridge--mode-line-format` の出力 (`"lsp-bridge"`) なので、この関数を上書きして misc-info 側も lighter (=「橋」) で描画するようにした
  - **NOTE**: upstream の内部関数を上書きしているため、lsp-bridge 更新で `lsp-bridge--mode-line-format` の定義が変わったら追従が必要 (コメントに明記済み)

## Test plan

- [x] 稼働中の Emacs にライブ評価し、lsp-bridge 有効バッファ (`BaseInfo.php`) のモードライン misc-info が `"橋 "` (face `lsp-bridge-alive-mode-line`) になることを確認
- [x] `home-manager switch --flake '.#nanasess@wsl-gentoo'` 成功
- [x] デプロイ済み `~/.emacs.d/init.el` に変更が反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * LSP-Bridge のモードライン表示が doom-modeline と正しく連携するよう改善しました。プロセスの稼働状態に応じてステータス表示の色が変わるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->