### PR TITLE
feat(ghostty): GhostInTheWSL 用 config を home-manager で出力

### DIFF
--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -96,6 +96,21 @@ in
       ${pkgs.ghostty}/share/ghostty/themes/ "$ghostty_dir/themes/"
   '';
 
+  # GhostInTheWSL (Codavo/ghostinthewsl) 向け設定を %LOCALAPPDATA%\ghostinthewsl\ にコピー
+  # README は %APPDATA% と記載するが誤り。実装 (src/os/xdg.zig) では XDG ベースで解決し、
+  # Windows では $XDG_CONFIG_HOME 未設定時に %LOCALAPPDATA% (AppData\Local) を見る。
+  # (Windows port (%LOCALAPPDATA%\ghostty) と同じ env var)
+  # 探索順: config.ghostinthewsl (exe隣) → %LOCALAPPDATA%\ghostinthewsl\config (legacy)
+  #   → %LOCALAPPDATA%\ghostinthewsl\config.ghostinthewsl。後勝ちで XDG が exe隣を上書きする。
+  # themes/ も同梱されない想定のため Nix パッケージ付属の themes/ を同期する。
+  home.activation.ghostinthewslConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    gitw_dir="/mnt/c/Users/${config.home.username}/AppData/Local/ghostinthewsl"
+    install -Dm644 ${ghostty.ghostinthewslConfigFile} "$gitw_dir/config.ghostinthewsl"
+    mkdir -p "$gitw_dir/themes"
+    ${pkgs.rsync}/bin/rsync -rt --delete \
+      ${pkgs.ghostty}/share/ghostty/themes/ "$gitw_dir/themes/"
+  '';
+
 
   # WSL 固有の zsh 設定
   programs.zsh.initContent = lib.mkAfter ''

--- a/modules/ghostty/default.nix
+++ b/modules/ghostty/default.nix
@@ -23,16 +23,35 @@ let
     copy-on-select = "clipboard";
   };
 
-  # Windows 版固有の追加設定
+  # Windows で動作する版に共通のフォントフォールバック
+  # - Segoe UI Symbol を追加フォールバック
+  #   Ghostty 自動フォールバックリスト (CodepointResolver.zig) に seguisym.ttf が
+  #   含まれておらず、U+23F5 (⏵) 等の記号が豆腐になるため明示指定
+  windowsFontFamily = settings.font-family ++ [ "Segoe UI Symbol" ];
+
+  # Windows port (PR #12167) 固有の追加設定
   # - command: 起動時に WSL の Gentoo-systemd ディストリをログインシェルで立ち上げる
   #   "direct:" プレフィックスを付けて /bin/sh -c ラップを回避 (Windows には sh が無い)
   #   --cd ~ でホームディレクトリに入る (WezTerm の default_cwd と等価)
-  # - font-family: Segoe UI Symbol を追加フォールバック
-  #   Ghostty 自動フォールバックリスト (CodepointResolver.zig) に seguisym.ttf が
-  #   含まれておらず、U+23F5 (⏵) 等の記号が豆腐になるため明示指定
   windowsSettings = settings // {
     command = "direct:wsl.exe -d Gentoo-systemd --cd ~";
-    font-family = settings.font-family ++ [ "Segoe UI Symbol" ];
+    font-family = windowsFontFamily;
+  };
+
+  # GhostInTheWSL (Codavo/ghostinthewsl) 固有の設定
+  # ConPTY を経由せず Hyper-V ソケットのブリッジで WSL2 の Linux PTY に直結するため、
+  # Windows port のような command = "direct:wsl.exe ..." は不要 (ブリッジが WSL 接続を担う)。
+  # - working-directory: デフォルト (inherit 相当) だと起動プロセス (Windows 側 exe) の
+  #   cwd を引き継ぎ、/mnt/c/.../zig-out/bin で WSL シェルが起動してしまう。
+  #   そこに blocked な .envrc があると direnv が zsh 初期化中に出力し、p10k instant
+  #   prompt の警告を誘発する。
+  #   GhostInTheWSL では `home` は無効 (src/Surface.zig の WorkingDirectory.value() が
+  #   .home/.inherit に対し null を返し、ブリッジの cwd が空 → Windows cwd へフォールバック
+  #   するだけで、upstream のような passwd home 解決が繋がっていない)。
+  #   .path の明示パスのみブリッジへ cwd として渡るため、WSL ホームを直接指定する。
+  ghostinthewslSettings = settings // {
+    font-family = windowsFontFamily;
+    working-directory = "/home/nanasess";
   };
 
   # home-manager の programs.ghostty が内部で使っているのと同じフォーマッタ
@@ -43,10 +62,12 @@ let
   };
 
   configFile = pkgs.writeText "ghostty-config.ghostty" (renderConfig windowsSettings);
+  ghostinthewslConfigFile = pkgs.writeText "config.ghostinthewsl" (renderConfig ghostinthewslSettings);
 in
 {
-  # settings / configFile を他のモジュール (hosts/*.nix) から参照できるように公開
+  # settings / configFile / ghostinthewslConfigFile を
+  # 他のモジュール (hosts/*.nix) から参照できるように公開
   _module.args.ghostty = {
-    inherit settings configFile;
+    inherit settings configFile ghostinthewslConfigFile;
   };
 }


### PR DESCRIPTION
## Summary

- [Codavo/ghostinthewsl](https://github.com/Codavo/ghostinthewsl)（ConPTY をバイパスし Hyper-V ソケットのブリッジで WSL2 の Linux PTY に直結する Windows ネイティブ Ghostty）向けに `config.ghostinthewsl` を home-manager で生成・配置する。
- 既存の Ghostty Windows port と同一の共有 `settings` から設定を生成し、両者を一元管理できるようにする。

## Changes

- **modules/ghostty/default.nix**
  - Windows 共通のフォントフォールバック（`Segoe UI Symbol`）を `windowsFontFamily` として切り出し、Windows port と GhostInTheWSL で共有
  - `ghostinthewslSettings` / `ghostinthewslConfigFile` を追加し `_module.args.ghostty` で公開
  - ブリッジが WSL 接続を担うため `command = "direct:wsl.exe ..."` は付与しない
  - `working-directory`: `home` は GhostInTheWSL では **無効**（`src/Surface.zig` の `WorkingDirectory.value()` が `.home` / `.inherit` に `null` を返し、ブリッジの cwd が空 → Windows cwd へフォールバックする。upstream のような passwd home 解決が繋がっていない）。`.path` の明示パスのみブリッジへ cwd として渡るため、WSL ホーム `/home/nanasess` を直接指定
- **hosts/wsl-gentoo.nix**
  - `%LOCALAPPDATA%\ghostinthewsl\` へ `config.ghostinthewsl` と `themes/` を同期
  - README は `%APPDATA%` と記載するが**誤り**。実装（`src/os/xdg.zig`）は XDG ベースで解決し、Windows では `$XDG_CONFIG_HOME` 未設定時に `%LOCALAPPDATA%`（`AppData\Local`）を参照する（Windows port と同じ env var）

## Test plan

- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` が成功
- [x] 生成された `config.ghostinthewsl` の内容を確認（フォント・テーマ・`working-directory = /home/nanasess`）
- [x] 実機で GhostInTheWSL を起動し、`/home/nanasess` から起動することを確認
- [x] 絵文字（😂🗿 等）の描画が正常であることを確認
- [ ] CI（`nix flake check` + 各ホストの `activationPackage` build）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * WSL環境でGhostInTheWSLの設定が自動的にセットアップされるようになりました
  * フォント設定の統一と改善を実施しました
  * Nix パッケージ付属のテーマが GhostInTheWSL 側へ自動同期されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->