### PR TITLE
feat(mackerel): LibreHardwareMonitor を Mackerel カスタムメトリック化

### DIFF
--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -97,6 +97,17 @@ in
   '';
 
 
+  # LibreHardwareMonitor -> Mackerel カスタムメトリック (modules/mackerel/)
+  # Windows 上の mackerel-agent が data.json を取得しメトリック化する。
+  # 主 conf は apikey 平文 + Program Files 読取専用のため home-manager では触らず、
+  # プラグイン本体と include フラグメントだけをユーザープロファイル配下へ配置する。
+  # 主 conf 側に手動で include = 'C:\Users\nanasess\mackerel\conf.d\*.conf' を一度追記する。
+  home.activation.mackerelLhm = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    deploy_dir="/mnt/c/Users/${config.home.username}/mackerel"
+    install -Dm644 ${../modules/mackerel/lhm-metrics.ps1} "$deploy_dir/lhm-metrics.ps1"
+    install -Dm644 ${../modules/mackerel/lhm.conf} "$deploy_dir/conf.d/lhm.conf"
+  '';
+
   # WSL 固有の zsh 設定
   programs.zsh.initContent = lib.mkAfter ''
     # VS Code PATH (WSL)

--- a/modules/mackerel/lhm-metrics.ps1
+++ b/modules/mackerel/lhm-metrics.ps1
@@ -1,0 +1,65 @@
+# LibreHardwareMonitor (data.json) -> Mackerel custom metric plugin.
+#
+# NOTE: Comments are intentionally ASCII-only. Windows PowerShell 5.1 reads a
+# BOM-less file as the system ANSI codepage (CP932 on Japanese Windows), and
+# multibyte Japanese bytes corrupt parsing. Japanese rationale lives in the
+# home-manager module (hosts/wsl-gentoo.nix) and conf.d/lhm.conf instead.
+#
+# Executed by the Windows mackerel-agent. Walks the LHM sensor tree and emits
+# Mackerel custom-metric lines: <metric_name>\t<value>\t<epoch>
+# - Metric name is derived from each sensor's SensorId (unique).
+# - Values are unit-suffixed strings ("12.1 V", "38.7 C"); the numeric part only
+#   is extracted. Sensors without a numeric reading (e.g. "-") are skipped.
+# - On fetch failure (LHM stopped) it exits cleanly with no output.
+#
+# Filtering keeps the host under Mackerel's 200-metrics-per-host limit:
+# - Global: Type in Temperature / Fan / Power / Load (all hardware).
+# - Aquacomputer high flow NEXT (USB vendor 0C70 / product F012) water loop:
+#   additionally Flow / Level (Water Quality) / Conductivity. Water temperature
+#   is already covered by the global Temperature rule.
+
+$ErrorActionPreference = 'Stop'
+
+$Uri = 'http://localhost:8100/data.json'
+
+try {
+    $data = Invoke-RestMethod -Uri $Uri -TimeoutSec 5
+}
+catch {
+    exit 0
+}
+
+$epoch = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+
+$GlobalTypes = @('Temperature', 'Fan', 'Power', 'Load')
+$WaterPrefix = '/usbhid/0C70/F012'
+$WaterTypes = @('Flow', 'Level', 'Conductivity')
+
+function Emit-Node {
+    param($node)
+
+    if ($node.SensorId -and ($node.Value -match '-?\d+(\.\d+)?')) {
+        $type = $node.Type
+        $include = $false
+        if ($GlobalTypes -contains $type) {
+            $include = $true
+        }
+        elseif ($node.SensorId.StartsWith($WaterPrefix) -and ($WaterTypes -contains $type)) {
+            $include = $true
+        }
+
+        if ($include) {
+            $value = [regex]::Match($node.Value, '-?\d+(\.\d+)?').Value
+            # mackerel-agent prepends "custom." to plugin metric names automatically,
+            # so emit "lhm.*" here (NOT "custom.lhm.*") to avoid a doubled "custom." prefix.
+            $name = 'lhm' + ($node.SensorId -replace '[^A-Za-z0-9]', '.')
+            Write-Output ("{0}`t{1}`t{2}" -f $name, $value, $epoch)
+        }
+    }
+
+    foreach ($child in $node.Children) {
+        Emit-Node $child
+    }
+}
+
+Emit-Node $data

--- a/modules/mackerel/lhm.conf
+++ b/modules/mackerel/lhm.conf
@@ -1,0 +1,19 @@
+# LibreHardwareMonitor カスタムメトリック設定 (mackerel-agent include フラグメント)
+#
+# 主 conf (C:\Program Files\Mackerel\mackerel-agent\mackerel-agent.conf) は apikey を
+# 平文で保持し Program Files 配下で管理者権限が必要なため home-manager では触らない。
+# 代わりに主 conf へ一度だけ手動で以下を追記し、本フラグメントを include させる:
+#
+#   include = 'C:\Users\nanasess\mackerel\conf.d\*.conf'
+#
+# このファイルは home-manager で管理し、activation で
+# C:\Users\nanasess\mackerel\conf.d\lhm.conf へコピーされる。
+#
+# command は配列形式で指定する。文字列形式だと Windows ではシェル経由でパースされ、
+# パスを囲む "..." がクオート二重化で壊れ ("-File '\"C:\...\"'" になり PowerShell が
+# パス無効エラー → バナーが stdout に漏れて metric parse 失敗) る。配列形式なら各要素を
+# そのまま CreateProcess へ渡すためシェル解釈もクオート問題も発生しない。
+# 各要素は TOML リテラル文字列 (シングルクォート) でバックスラッシュ escape を回避する。
+
+[plugin.metrics.lhm]
+command = ['powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'C:\Users\nanasess\mackerel\lhm-metrics.ps1']


### PR DESCRIPTION
## 概要

Windows 上の `mackerel-agent` から LibreHardwareMonitor (LHM) の Remote Web Server (`data.json`, port 8100) を取得し、ハードウェアセンサーを Mackerel のカスタムメトリックとして報告する仕組みを home-manager で管理する。

「LHM の web サーバー + Mackerel でハードウェア監視は可能か?」の実証として、登録ホスト `DESKTOP-HV9026L` で **`custom.lhm.*` 119 件 + 既定 29 件**の流入を確認済み。

## 変更内容

| ファイル | 役割 |
|---|---|
| `modules/mackerel/lhm-metrics.ps1` | `data.json` を走査し `lhm.*\t<value>\t<epoch>` を出力するプラグイン本体 |
| `modules/mackerel/lhm.conf` | `[plugin.metrics.lhm]` の include フラグメント (秘密なし) |
| `hosts/wsl-gentoo.nix` | activation で `C:\Users\nanasess\mackerel\` へ配置 |

## 設計上のポイント (ハマりどころ)

- **秘密の分離**: 主 conf は apikey 平文 + Program Files 読取専用のため home-manager では触らず、`include` で外部フラグメントを読ませる。主 conf への include 行追記のみ一度手動 (管理者権限)。
- **メトリック上限**: Mackerel Standard は 200 メトリック/ホスト。Type が Temperature / Fan / Power / Load に絞り、加えて Aquacomputer high flow NEXT (vendor `0C70` / product `F012`) の Flow / Water Quality(Level) / Conductivity を送る (約120件)。
- **`custom.` 二重前置**: mackerel-agent がプラグイン出力名へ `custom.` を自動前置するため `lhm.*` を出力する (`custom.lhm.*` を出すと `custom.custom.lhm.*` に二重化)。
- **command 配列形式**: 文字列形式は Windows でシェル経由パースされ、パスを囲む `"..."` がクオート二重化で壊れるため配列形式を使う。
- **PowerShell 5.1 のエンコーディング**: BOM 無し UTF-8 を CP932 解釈し日本語コメントで構文が壊れるため、ps1 のコメントは ASCII のみ。

## 適用手順 (受け手側の手動作業)

1. `home-manager switch` でファイル配置
2. 主 conf (`C:\Program Files\Mackerel\mackerel-agent\mackerel-agent.conf`) に管理者権限で1回だけ追記:
   `include = 'C:\Users\nanasess\mackerel\conf.d\*.conf'`
3. `Restart-Service mackerel-agent`

## 検証

- `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` 成功
- Mackerel API で `custom.lhm.*` 119 件到達、high flow NEXT の水温 39.1℃ / Flow 117 L/h / Water Quality 96.9% / Conductivity 51.4 µS/cm を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * WSL 環境で、LibreHardwareMonitor のセンサー値を Mackerel のカスタムメトリクスとして収集・送信できるようになりました。
  * 温度、ファン、電力、負荷に加え、対応機器の水冷関連データも扱えます。
* **設定**
  * 起動時に必要な設定やスクリプトが自動配置されるようになり、手動セットアップの手間が減りました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->