### PR TITLE
fix(zsh): .env.local 読み込みを対話シェル限定にして非対話プローブの汚染を防ぐ

### DIFF
--- a/modules/zsh/default.nix
+++ b/modules/zsh/default.nix
@@ -9,21 +9,31 @@
       export CLAUDE_CONFIG_DIR=$HOME/.config/claude
 
       # 1Password Environments から秘匿情報を読み込む（タイムアウト付き）
-      if [[ -p "$ZDOTDIR/.env.local" ]]; then
-        _OP_ENV_CONTENT=$(timeout 1 cat "$ZDOTDIR/.env.local" 2>/dev/null)
-        if [[ -n "$_OP_ENV_CONTENT" ]]; then
+      #
+      # 対話シェル限定にする理由: .zshenv は zsh の全起動 (非対話の `zsh -c`,
+      # scp/rsync/git-over-ssh, WSL の `wsl.exe -- <cmd>` 経由のプローブ等) で
+      # source される。ここで FIFO を読む・stderr に警告を出すと、コマンド出力を
+      # 捕捉するツールを壊す。実害例: ghostinthewsl の `wslinfo --vm-id` 出力に
+      # 警告が混入し VM-ID パース失敗 → vsock ConnectFailed (Windows 起動直後、
+      # 1Password GUI 未起動時)。非対話シェルで秘匿情報が必要なら op run/op read を
+      # 明示的に使う (プロジェクト方針)。
+      if [[ -o interactive ]]; then
+        if [[ -p "$ZDOTDIR/.env.local" ]]; then
+          _OP_ENV_CONTENT=$(timeout 1 cat "$ZDOTDIR/.env.local" 2>/dev/null)
+          if [[ -n "$_OP_ENV_CONTENT" ]]; then
+            set -a
+            source <(printf '%s\n' "$_OP_ENV_CONTENT")
+            set +a
+          else
+            echo "\e[33m[WARNING] Could not load secrets: 1Password is not running.\e[0m" >&2
+            echo "\e[33m          Please start 1Password and open a new shell.\e[0m" >&2
+          fi
+          unset _OP_ENV_CONTENT
+        elif [[ -f "$ZDOTDIR/.env.local" ]]; then
           set -a
-          source <(printf '%s\n' "$_OP_ENV_CONTENT")
+          source "$ZDOTDIR/.env.local"
           set +a
-        else
-          echo "\e[33m[WARNING] Could not load secrets: 1Password is not running.\e[0m" >&2
-          echo "\e[33m          Please start 1Password and open a new shell.\e[0m" >&2
         fi
-        unset _OP_ENV_CONTENT
-      elif [[ -f "$ZDOTDIR/.env.local" ]]; then
-        set -a
-        source "$ZDOTDIR/.env.local"
-        set +a
       fi
 
       export ENHANCD_HYPHEN_NUM=50


### PR DESCRIPTION
## 概要

`.zshenv`（home-manager の `programs.zsh.envExtra`）にある `.env.local` 秘匿情報読み込みブロックを、対話シェル限定 (`[[ -o interactive ]]`) で実行するように変更します。

## 背景・問題

`.env.local` 読み込みは `envExtra`（= `.zshenv`）に置かれており、zsh の**全起動**（非対話の `zsh -c`、scp/rsync/git-over-ssh、WSL の `wsl.exe -- <cmd>` 経由のプローブ等）で source されていました。1Password GUI 未起動時に stderr へ出す警告が、コマンド出力を捕捉するツールを壊します。

実害として確認したケース:

- Windows 起動直後（Linux 1Password GUI 未起動）に GhostInTheWSL を起動すると `error starting IO thread: error.ConnectFailed` で WSL に接続できない
- 原因: GhostInTheWSL が `wsl.exe -- wslinfo --vm-id` を実行 → ログインシェル経由で `.zshenv` が source → 警告が stderr→stdout マージで `wslinfo` 出力に混入 → VM-ID パース失敗 → vsock リトライ枯渇 → `ConnectFailed`
- 1Password GUI を起動すると FIFO に secrets が注入されて警告が消え、出力がクリーンな GUID のみになって復旧していた（=「GUI 起動で直る」の正体は WSL 起動ではなく警告抑止）
- `%TEMP%\ghostty-wsl.log` で失敗時 169B（警告混入）/ 成功時 36B（GUID のみ）を実証

## 変更内容

- `modules/zsh/default.nix`: `.env.local` 読み込みブロック全体を `if [[ -o interactive ]]` で囲む
- 非対話シェルでは FIFO 読み・警告出力を一切行わない
- 対話シェルでの挙動（1Password 未起動時の警告表示含む）は従来どおり維持

`.zshenv` は stdout/stderr に出力してはいけない、という一般則に沿った修正です。非対話で秘匿情報が必要な場合は `op run` / `op read` を明示使用する方針（CLAUDE.md）と整合します。

## テスト

- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` 成功
- [x] 生成された `.zshenv` に `[[ -o interactive ]]` ガードが入っていることを確認
- [x] 実機適用後、Windows 起動直後の GhostInTheWSL 起動が成功することを確認（報告: 問題なく起動しました）

## 補足（別途検討）

fork `nanasess/ghostinthewsl` 側でも多重防御が可能（いずれか1つで解消）:
- `wsl.exe --exec wslinfo --vm-id` でシェル rc をバイパス
- プローブで stderr を stdout にマージしない
- `parseGuid` を GUID 抽出する寛容パースに

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 対話シェルでのみ秘密情報の読み込みを行うようになり、非対話シェルで意図せず設定が読み込まれる問題を防ぎました。
  * `.env.local` が FIFO の場合の読み込みや警告表示、後始末の挙動は対話シェル内で引き続き維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->