### PR TITLE
feat(mackerel): Gaming PC を client-pc:gaming-pc ロールに割り当て

### DIFF
--- a/modules/mackerel/lhm.conf
+++ b/modules/mackerel/lhm.conf
@@ -15,5 +15,14 @@
 # そのまま CreateProcess へ渡すためシェル解釈もクオート問題も発生しない。
 # 各要素は TOML リテラル文字列 (シングルクォート) でバックスラッシュ escape を回避する。
 
+# ホストのロール割り当て。Mackerel の connectivity(死活監視)から本機を除外するための
+# ロール。クライアント端末はスリープ/シャットダウンで接続断するため死活監視対象から外す。
+# terraform 側 (skirnir.co.jp-terraform の mackerel_monitor.connectivity の exclude_scopes
+# = ["client-pc:gaming-pc"]) と対応させる。roles を変更したら mackerel-agent を再起動する。
+# roles は TOML トップレベルキーなので [plugin.*] セクションより前に置く。
+# (現状 conf.d\*.conf にマッチする include フラグメントは本ファイルのみ。複数になると
+#  読込順が不定で roles が後勝ち上書きされる点に注意。)
+roles = ["client-pc:gaming-pc"]
+
 [plugin.metrics.lhm]
 command = ['powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'C:\Users\nanasess\mackerel\lhm-metrics.ps1']


### PR DESCRIPTION
## 概要

Gaming PC (`DESKTOP-HV9026L`) を Mackerel の `client-pc:gaming-pc` ロールに所属させ、**connectivity(死活監視)から除外**する。クライアント端末はスリープ/シャットダウンで接続断するため、スリープのたびに connectivity アラートが通知されていた。

terraform 側 (`skirnir.co.jp-terraform` PR #52, マージ済み・apply 済み) で `mackerel_monitor.connectivity` の `exclude_scopes = ["client-pc:gaming-pc"]` を設定済み。本 PR でホストを当該ロールに所属させ、除外を成立させる。

## 変更

- `modules/mackerel/lhm.conf`(mackerel-agent include フラグメント)に `roles = ["client-pc:gaming-pc"]` を追加
- 主 conf は apikey 平文 + Program Files 読取専用のため従来どおり home-manager では触らない
- `roles` は TOML トップレベルキーのため `[plugin.*]` セクションより前に配置

## 検証

- `nix build .#homeConfigurations."nanasess@wsl-gentoo".activationPackage` 成功

## ⚠️ 反映手順

`home-manager switch` で `/mnt/c/Users/nanasess/mackerel/conf.d/lhm.conf` に配置されたあと、**Windows 側で mackerel-agent サービスの再起動が必要**(roles は登録時に反映されるため)。再起動後、ホストが `client-pc:gaming-pc` ロールに所属し、スリープで connectivity が発火しなくなることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ホストのロール割り当てを明示的に設定できるようになりました。
  * 死活監視の対象外にする前提の設定が、構成内で分かりやすく定義されるようになりました。

* **ドキュメント**
  * 設定の記述順に関する注意書きを追加しました。
  * ロール設定の意図が分かる説明コメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->