### PR TITLE
fix(portage): 1Password GUI を app-admin/1password::jaredallard に整合

### DIFF
--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -23,13 +23,15 @@ let
     # 常駐は systemd ユーザーサービス (modules/yaskkserv2.nix) で管理。
     "app-i18n/yaskkserv2"
 
-    # 1Password (GURU overlay)
+    # 1Password (CLI は GURU overlay、GUI は jaredallard overlay)
     # Nix /nix/store では setgid を付与できず Linux GUI と通信できないため、
     # portage 経由で /usr/bin/op (setgid onepassword-cli) を導入する。
     # GUI は ~/.config/zsh/.env.local (FIFO) への secrets 注入と
     # SSH agent (~/.1password/agent.sock) を提供する。
+    # GUI は app-admin/1password::jaredallard を正とする (modules/portage.nix 参照。
+    # GURU gui-apps/1password は古くダウングレードすると起動不可のため不採用)
     "app-misc/1password-cli"
-    "gui-apps/1password"
+    "app-admin/1password"
 
     # mise PHP ビルド依存（asdf-php workflow.yml 参照）
     "dev-db/postgresql"

--- a/modules/portage.nix
+++ b/modules/portage.nix
@@ -102,11 +102,9 @@
     dev-python/click
     media-libs/mesa
 
-    # 1Password (GURU overlay)
+    # 1Password CLI (GURU overlay)。GUI は app-admin/1password::jaredallard (stable のため keyword 不要)
     app-misc/1password-cli ~amd64
-    gui-apps/1password ~amd64
     acct-group/onepassword-cli ~amd64
-    acct-group/1password ~amd64
   '';
 
   xdg.configFile."portage/package.unmask".text = ''
@@ -117,10 +115,12 @@
 
   # #48 移行済みパッケージを除外（terraform, op-cli-bin）
   # 1password 系は PR #85 で portage 管理に戻したためライセンス受諾を復活
+  # GUI は app-admin/1password::jaredallard 8.12.12 を正とする
+  # (GURU gui-apps/1password は 8.11.22 と古く、ダウングレードすると起動不可のため不採用)
   xdg.configFile."portage/package.license".text = ''
     www-client/google-chrome google-chrome
     app-misc/1password-cli all-rights-reserved
-    gui-apps/1password all-rights-reserved
+    app-admin/1password all-rights-reserved
   '';
 
   xdg.configFile."portage/package.use/ffmpeg".text = ''


### PR DESCRIPTION
## 概要

world 更新後、`app-admin/1password-8.12.12::jaredallard` が license 未受諾で **masked 警告**を出していた。実機の 1Password GUI は jaredallard 版 8.12.12 で全機能が正常動作しているため、これを正として license を受諾しマスクを解消する。

## 背景

`portage.nix` は `gui-apps/1password` (GURU) への移行を宣言していたが、実際には移行が完了しておらず GUI 実体は `app-admin/1password::jaredallard` のままだった。GURU 版は `8.11.22-r1` と古く、**ダウングレードすると 1Password が起動しなくなる**ため、移行は見送り 8.12.12 (jaredallard) を正とする。

## 変更

- `package.license`: `gui-apps/1password` → `app-admin/1password all-rights-reserved` に置換しマスク解消
- `package.accept_keywords`: GURU gui 専用の `gui-apps/1password` / `acct-group/1password` を削除
  (`app-admin/1password` は `KEYWORDS=amd64` stable のため keyword 不要)
- CLI (`app-misc/1password-cli`) と `acct-group/onepassword-cli` は GURU のまま維持

## 検証

- `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` 成功
- `emerge -pv app-admin/1password` で masked 警告が消え、`8.12.24` へのアップグレードが認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Portage の 1Password 関連設定を更新し、GURU/Jaredallard での取得対象を整理しました。
  * 1Password の許諾対象を最新のパッケージに合わせて調整し、コメントも前提内容を反映しました。
  * 不要・不整合になっていたエントリを削除し、ライセンス/キーワード設定の整合性を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->