### PR TITLE
feat(yaskkserv2): Nix パッケージ化で ubuntu にも展開し両ホスト共通化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,9 @@ modules/
     default.nix        -- Ghostty 共有設定（Linux native / Windows port (PR #12167) 両対応、_module.args で公開）
   portage.nix          -- Portage 設定（WSL Gentoo 用、xdg.configFile で ~/.config/portage/ に書き出し）
   onedrive.nix         -- OneDrive 設定（WSL Gentoo 用）
+  yaskkserv2.nix       -- SKK 辞書サーバ（systemd ユーザーサービス。wsl-gentoo / ubuntu 共通）
+pkgs/
+  yaskkserv2.nix       -- yaskkserv2 の自作 Nix derivation（buildRustPackage、nixpkgs 未収録のため）
 .github/workflows/
   check.yml            -- CI 設定
 ```
@@ -114,6 +117,9 @@ modules/
 | East Asian Ambiguous 文字幅 | locale-eaw EAW-CONSOLE | glibc wcwidth + WezTerm cell_widths + Emacs char-width-table を統一 |
 | Portage 設定 | home-manager (xdg.configFile) | `~/.config/portage/` に書き出し、`/etc/portage/` から個別にシンボリックリンク |
 | システムパッケージ一覧 | Nix リスト + チェックスクリプト | 各ホストの nix ファイルで宣言、`check-system-packages` で差分確認 |
+| SKK 辞書サーバ (yaskkserv2) | Nix ビルド (`pkgs/yaskkserv2.nix`) + systemd ユーザーサービス (`modules/yaskkserv2.nix`) | nixpkgs / apt に無いため上流を `buildRustPackage`。全ホスト同一バイナリ + ユーザーパス辞書 (`~/.local/share/yaskkserv2/all`) で sudo 不要・共通化 |
+
+**プラットフォーム非依存化の判断基準**: portage / apt など特定ホストのパッケージマネージャに依存する構成は、入手経路が「バイナリ + 付随ツール」だけの問題であれば **Nix パッケージ化 (必要なら `pkgs/` に自作 derivation) して全ホスト共通化する**ことを優先する。辞書・データ類はシステムパス (`/usr/lib` 等、要 sudo) ではなくユーザーパス (`xdg.dataHome` 配下) に置き、セットアップを sudo レスにする。yaskkserv2 はこの方針で wsl-gentoo (旧 portage) と ubuntu を統一した先例 (PR #110)。
 
 ### 移行元リポジトリ (TODO)
 

--- a/README.md
+++ b/README.md
@@ -49,22 +49,26 @@ sudo ln -sfn ~/.config/portage/repos.conf /etc/portage/repos.conf
 sudo getuto
 ```
 
-### SKK 辞書サーバ (yaskkserv2) のセットアップ（WSL Gentoo のみ）
+### SKK 辞書サーバ (yaskkserv2) のセットアップ（WSL Gentoo / Ubuntu 共通）
 
-Emacs (nskk) の辞書本体を skkserv (yaskkserv2) に逃がし、nskk が全辞書を起動時にトライ索引へ全件展開することで full GC が 20-50 秒かかる問題を回避します。サーバは `modules/yaskkserv2.nix` が **systemd ユーザーサービス**として管理します（`/etc` も sudo も OpenRC も不要、ユーザー権限で `~/.config/yaskkserv2/` を読む）。バイナリと配信辞書のみ sudo で用意します。
+Emacs (nskk) の辞書本体を skkserv (yaskkserv2) に逃がし、nskk が全辞書を起動時にトライ索引へ全件展開することで full GC が 20-50 秒かかる問題を回避します。サーバは `modules/yaskkserv2.nix` が **systemd ユーザーサービス**として管理します（`/etc` も sudo も OpenRC も不要）。
+
+バイナリ (`yaskkserv2` / `yaskkserv2_make_dictionary`) は nixpkgs / apt に無いため `pkgs/yaskkserv2.nix` で **Nix ビルド**し、両ホストで同一バイナリを共有します。配信辞書はユーザーパス `~/.local/share/yaskkserv2/all` に置くため、セットアップは **すべて sudo 不要**です。
 
 ```bash
-# 1. yaskkserv2 をインストール（SKK-JISYO.L も依存で入る）
-sudo emerge -av app-i18n/yaskkserv2
+# 1. home-manager switch でバイナリ導入 + 設定生成 + ユーザーサービス起動
+#    （<host> は wsl-gentoo または ubuntu）
+home-manager switch --flake '.#nanasess@<host>'
 
-# 2. 配信辞書を SKK-JISYO.all.utf8 からビルド（辞書更新時のみ再実行）
-sudo install -d /usr/lib/yaskkserv2
-sudo yaskkserv2_make_dictionary \
-  --dictionary-filename /usr/lib/yaskkserv2/all \
+# 2. 配信辞書を SKK-JISYO.all.utf8 からビルド（初回 + 辞書更新時のみ再実行）
+#    yaskkserv2_make_dictionary は上記 switch で ~/.nix-profile/bin に入る
+mkdir -p ~/.local/share/yaskkserv2
+yaskkserv2_make_dictionary \
+  --dictionary-filename ~/.local/share/yaskkserv2/all \
   --utf8 "$HOME/OneDrive - Skirnir Inc/emacs/ddskk/SKK-JISYO.all.utf8"
 
-# 3. home-manager switch で設定生成 + ユーザーサービス起動
-home-manager switch --flake '.#nanasess@wsl-gentoo'
+# 3. 辞書生成後にサービスを再起動して読み込ませる
+systemctl --user restart yaskkserv2
 
 # 4. 稼働確認
 systemctl --user status yaskkserv2
@@ -73,7 +77,7 @@ systemctl --user status yaskkserv2
 python3 -c 'import socket; s=socket.create_connection(("127.0.0.1",1178),2); s.sendall("1あい ".encode()); print(s.recv(8192).decode("utf-8","replace"))'
 ```
 
-設定 (`modules/yaskkserv2.nix`) を変更したら `home-manager switch` で自動反映されます（手動再起動が要る場合は `systemctl --user restart yaskkserv2`）。`listen-address = 127.0.0.1`（LAN へ露出しない）ですが、WSL2 の localhostForwarding 経由で Windows からも `localhost:1178` で接続できます。
+設定 (`modules/yaskkserv2.nix`) を変更したら `home-manager switch` で自動反映されます（手動再起動が要る場合は `systemctl --user restart yaskkserv2`）。`listen-address = 127.0.0.1`（LAN へ露出しない）ですが、WSL2 では localhostForwarding 経由で Windows からも `localhost:1178` で接続できます。
 
 ### システムパッケージの確認
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
             ./home.nix
             ./hosts/ubuntu.nix
             ./modules/onedrive.nix
+            ./modules/yaskkserv2.nix
             ./modules/emacs
             ./modules/zsh
             ./modules/ghostty

--- a/hosts/ubuntu.nix
+++ b/hosts/ubuntu.nix
@@ -135,6 +135,18 @@ in
   '';
 
   dconf.settings = {
+    # ibus-skk の辞書設定。yaskkserv2 (skkserv) を辞書サーバとして参照する。
+    # encoding=UTF-8 が必須: yaskkserv2 は --midashi-utf8 で UTF-8 通信専用のため。
+    # ibus-skk (libskk) の既定は EUC-JP で、省略すると見出し語が化けて変換不能になる
+    # (ueno/ibus-skk src/engine.vala が encoding= を Skk.SkkServ へ渡す)。
+    # このコメントを消して encoding を外すと ibus-skk の漢字変換が壊れる。
+    "desktop/ibus/engine/skk" = {
+      dictionaries = [
+        "file=${config.home.homeDirectory}/.config/ibus-skk/user.dict,mode=readwrite,type=file"
+        "host=127.0.0.1,port=1178,type=server,encoding=UTF-8"
+      ];
+    };
+
     "org/gnome/settings-daemon/plugins/media-keys" = {
       custom-keybindings = [
         "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/"

--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -17,11 +17,9 @@ let
     "app-shells/zsh"
     "sys-apps/plocate"
 
-    # SKK 辞書サーバ (skkserv)。Emacs nskk の辞書本体をこのサーバへ逃がし、
-    # nskk のトライ索引 (~650MiB) が full GC を 20-50 秒占有する問題を解消する。
-    # RDEPEND の app-i18n/skk-jisyo で SKK-JISYO.L も入る。
-    # 常駐は systemd ユーザーサービス (modules/yaskkserv2.nix) で管理。
-    "app-i18n/yaskkserv2"
+    # SKK 辞書サーバ yaskkserv2 は Nix ビルド (pkgs/yaskkserv2.nix) で ubuntu と
+    # 共通化したため portage 管理から外した。常駐は systemd ユーザーサービス
+    # (modules/yaskkserv2.nix)、辞書は ~/.local/share/yaskkserv2/all (sudo 不要)。
 
     # 1Password (CLI は GURU overlay、GUI は jaredallard overlay)
     # Nix /nix/store では setgid を付与できず Linux GUI と通信できないため、

--- a/modules/yaskkserv2.nix
+++ b/modules/yaskkserv2.nix
@@ -1,4 +1,13 @@
-{ config, ... }:
+{ config, pkgs, ... }:
+let
+  # nixpkgs / apt には無いため上流をローカルでビルドする (pkgs/yaskkserv2.nix)。
+  # これにより wsl-gentoo と ubuntu で同一バイナリを共有し、両ホストとも
+  # sudo emerge / apt を経ずに yaskkserv2 + yaskkserv2_make_dictionary を得る。
+  yaskkserv2 = pkgs.callPackage ../pkgs/yaskkserv2.nix { };
+  # 配信辞書はユーザーパスに置く (sudo 不要)。yaskkserv2_make_dictionary で
+  # SKK-JISYO.all.utf8 からビルドする (詳細は README.md「SKK 辞書サーバ」節)。
+  dictionaryPath = "${config.xdg.dataHome}/yaskkserv2/all";
+in
 {
   # yaskkserv2 (skkserv) を systemd ユーザーサービスとして宣言管理する。
   # Emacs nskk の辞書本体をこのサーバへ逃がし、nskk が全辞書を起動時にトライ索引
@@ -6,16 +15,18 @@
   # full GC が 20-50 秒かかる問題を解消する (init.el の nskk 設定参照)。
   #
   # systemd ユーザーサービスなので /etc 書き込みも sudo も OpenRC も不要。ユーザー
-  # 権限で動き ~/.config を直接読める。ebuild 同梱の system unit (User=nobody、
-  # /etc/yaskkserv2.conf を読む、--midashi-utf8 無し) は使わない (disabled のまま)。
+  # 権限で動き ~/.config / ~/.local/share を直接読む。バイナリは Nix ビルド
+  # (pkgs/yaskkserv2.nix) なので wsl-gentoo でも portage は不要。
   #
-  # 事前準備 (sudo が要る部分。詳細は README.md「SKK 辞書サーバ」節):
-  #   sudo emerge -av app-i18n/yaskkserv2        # バイナリ + SKK-JISYO.L
-  #   sudo install -d /usr/lib/yaskkserv2        # 配信辞書を SKK-JISYO.all.utf8 から
-  #   sudo yaskkserv2_make_dictionary \          #   ビルド (辞書更新時のみ再実行)
-  #     --dictionary-filename /usr/lib/yaskkserv2/all \
+  # 事前準備 (sudo 不要。詳細は README.md「SKK 辞書サーバ」節):
+  #   nix build '.#homeConfigurations."nanasess@<host>".activationPackage'
+  #   yaskkserv2_make_dictionary \             # 配信辞書を SKK-JISYO.all.utf8 から
+  #     --dictionary-filename ~/.local/share/yaskkserv2/all \   # ビルド (辞書更新時のみ)
   #     --utf8 "$HOME/OneDrive - Skirnir Inc/emacs/ddskk/SKK-JISYO.all.utf8"
   # その後 `home-manager switch` でサービスが起動する。
+
+  # yaskkserv2_make_dictionary を PATH に通し、辞書の (再) ビルドを手元で行えるように。
+  home.packages = [ yaskkserv2 ];
 
   # サーバ設定。--config-filename でこのファイルを直接読ませる (/etc は経由しない)。
   # google 連携を有効化。notfound = ローカル辞書で見つからない語のみ Google 日本語
@@ -23,9 +34,9 @@
   # 注意: 変換キー (よみ) が Google に送信される。オフライン/プライバシー重視に
   # 戻すなら google-japanese-input = disable / google-suggest = disable に。
   xdg.configFile."yaskkserv2/yaskkserv2.conf".text = ''
-    dictionary = /usr/lib/yaskkserv2/all
+    dictionary = ${dictionaryPath}
     port = 1178
-    # 127.0.0.1 に限定 (LAN へ露出しない)。WSL2 の localhostForwarding により
+    # 127.0.0.1 に限定 (LAN へ露出しない)。WSL2 では localhostForwarding により
     # Windows 側からも localhost:1178 で到達できる。
     listen-address = 127.0.0.1
     max-connections = 16
@@ -43,7 +54,7 @@
     Service = {
       # --midashi-utf8: SKK-JISYO.all.utf8 は EUC-JP 不可文字を含むため UTF-8 で
       # 統一し、nskk 側 nskk-server-coding-system 'utf-8 (init.el) と整合させる。
-      ExecStart = "/usr/bin/yaskkserv2 --no-daemonize --midashi-utf8 --config-filename ${config.xdg.configHome}/yaskkserv2/yaskkserv2.conf";
+      ExecStart = "${yaskkserv2}/bin/yaskkserv2 --no-daemonize --midashi-utf8 --config-filename ${config.xdg.configHome}/yaskkserv2/yaskkserv2.conf";
       Restart = "on-failure";
       RestartSec = 3;
     };

--- a/pkgs/yaskkserv2.nix
+++ b/pkgs/yaskkserv2.nix
@@ -1,0 +1,35 @@
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, openssl }:
+
+# yaskkserv2 (skkserv) を Nix でパッケージ化する。nixpkgs / apt には無いため、
+# 上流 (wachikun/yaskkserv2) を rustPlatform.buildRustPackage で直接ビルドする。
+# これにより wsl-gentoo (portage) と ubuntu で同一バイナリを共有でき、どちらの
+# ホストも sudo emerge / apt を経ずに yaskkserv2 と yaskkserv2_make_dictionary を
+# 得られる (modules/yaskkserv2.nix で参照)。
+rustPlatform.buildRustPackage rec {
+  pname = "yaskkserv2";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "wachikun";
+    repo = "yaskkserv2";
+    rev = version;
+    hash = "sha256-bF8OHP6nvGhxXNvvnVCuOVFarK/n7WhGRktRN4X5ZjE=";
+  };
+
+  cargoHash = "sha256-cycs8Zism228rjMaBpNYa4K1Ll760UhLKkoTX6VJRU0=";
+
+  # reqwest が default-tls (OpenSSL) を要求するため pkg-config + openssl が必要。
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  # 一部のテストはネットワーク / 実辞書を要求するためビルド時は無効化する。
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Yet Another Skkserv 2 — SKK 辞書サーバ";
+    homepage = "https://github.com/wachikun/yaskkserv2";
+    license = with licenses; [ mit asl20 ];
+    platforms = platforms.unix;
+    mainProgram = "yaskkserv2";
+  };
+}


### PR DESCRIPTION
## 概要

[PR #95](https://github.com/nanasess/home-manager/pull/95) で wsl-gentoo に導入した yaskkserv2 (nskk の辞書本体を skkserv へ逃がし full GC スパイクを解消する構成) を **ubuntu にも適用**し、あわせて **両ホストを Nix パッケージで共通化**する。

`modules/emacs/init.el` は全ホスト共有のため、ubuntu も既に `nskk-dict-system-dictionary-files nil` + `localhost:1178` 参照になっており、**サーバ未起動でユーザー辞書のみに縮退**していた。本 PR でこのデグレも解消する。

## なぜ Nix パッケージ化で共通化するか

PR #95 が portage を使っていた理由は「バイナリと辞書ビルドツールの入手経路」のみ。ここを `pkgs/yaskkserv2.nix` の Nix ビルドで賄うと両ホストの差分が消え、辞書もユーザーパスに置けるため **両ホストとも sudo が完全に不要**になる。

| 項目 | PR #95 (wsl-gentoo) | 本 PR (両ホスト共通) |
|---|---|---|
| バイナリ | portage `/usr/bin/yaskkserv2` | Nix `pkgs/yaskkserv2.nix` |
| 辞書ビルドツール | portage 同梱 | 同 Nix パッケージが提供 |
| 辞書配置 | `/usr/lib/yaskkserv2/all` (要 sudo) | `~/.local/share/yaskkserv2/all` (sudo 不要) |
| セットアップ | `sudo emerge` + sudo 辞書ビルド | `home-manager switch` で完結 |

## 変更内容

- **pkgs/yaskkserv2.nix** (新規): `rustPlatform.buildRustPackage` で上流 v0.1.7 をビルド。`yaskkserv2` / `yaskkserv2_make_dictionary` を提供 (reqwest default-tls のため `pkg-config` + `openssl`)。
- **modules/yaskkserv2.nix**: バイナリを Nix パッケージ、辞書を `xdg.dataHome` 配下に変更しホスト非依存化。`yaskkserv2_make_dictionary` を `home.packages` で PATH に。
- **flake.nix**: ubuntu の modules に `./modules/yaskkserv2.nix` を追加。
- **hosts/wsl-gentoo.nix**: gentooPackages から `app-i18n/yaskkserv2` を削除 (Nix ビルドへ移行)。
- **hosts/ubuntu.nix**: ibus-skk も同じ yaskkserv2 を辞書サーバとして使えるよう、`dconf.settings` に skkserv 辞書設定 (`encoding=UTF-8`) を宣言追加。
- **README.md**: セットアップ手順を両ホスト共通・sudo レスに全面改訂。

## セットアップ手順（ホスト別）

辞書ソース `~/OneDrive - Skirnir Inc/emacs/ddskk/SKK-JISYO.all.utf8` が存在する前提。どちらも **sudo 不要**。

### Ubuntu（新規導入）

```bash
cd ~/.config/home-manager

# 1. バイナリ導入 + 設定生成 + ユーザーサービス起動
home-manager switch --flake '.#nanasess@ubuntu'

# 2. 配信辞書をユーザーパスにビルド（yaskkserv2_make_dictionary は switch で PATH に入る）
mkdir -p ~/.local/share/yaskkserv2
yaskkserv2_make_dictionary \
  --dictionary-filename ~/.local/share/yaskkserv2/all \
  --utf8 "$HOME/OneDrive - Skirnir Inc/emacs/ddskk/SKK-JISYO.all.utf8"

# 3. 辞書を読み込ませるためサービス再起動 → 稼働確認
systemctl --user restart yaskkserv2
systemctl --user status yaskkserv2

# 4. 変換動作確認（1/愛/相/... が返れば OK）
python3 -c 'import socket; s=socket.create_connection(("127.0.0.1",1178),2); s.sendall("1あい ".encode()); print(s.recv(8192).decode("utf-8","replace"))'
```

### WSL Gentoo（portage からの移行）

辞書パスが `/usr/lib/yaskkserv2/all` → `~/.local/share/yaskkserv2/all` に変わるため、**辞書をユーザーパスへ 1 回再ビルド**する（Nix 版ツールを使うので sudo 不要）。

```bash
cd ~/.config/home-manager

# 1. Nix バイナリへ切り替え + 設定再生成（ExecStart と辞書パスが更新される）
home-manager switch --flake '.#nanasess@wsl-gentoo'

# 2. 配信辞書をユーザーパスへ再ビルド
mkdir -p ~/.local/share/yaskkserv2
yaskkserv2_make_dictionary \
  --dictionary-filename ~/.local/share/yaskkserv2/all \
  --utf8 "$HOME/OneDrive - Skirnir Inc/emacs/ddskk/SKK-JISYO.all.utf8"

# 3. サービス再起動 → 稼働確認 → 変換確認
systemctl --user restart yaskkserv2
systemctl --user status yaskkserv2
python3 -c 'import socket; s=socket.create_connection(("127.0.0.1",1178),2); s.sendall("1あい ".encode()); print(s.recv(8192).decode("utf-8","replace"))'

# 4. （任意）portage 管理と旧システム辞書の後片付け。残しても害はない
sudo emerge --deselect app-i18n/yaskkserv2   # world から外す（アンインストールは -C）
sudo rm -rf /usr/lib/yaskkserv2              # 旧 /usr/lib 配下の配信辞書
```

## ibus-skk からの利用 (UTF-8 通信)

Emacs nskk だけでなく ibus-skk からも同じ yaskkserv2 を辞書サーバとして共用できる。ただし yaskkserv2 は `--midashi-utf8` で **UTF-8 通信専用**なのに対し、ibus-skk (libskk) の既定は **EUC-JP** のため、そのままでは見出し語が化けて変換できない (生プロトコルで `1/＆/&/` のような応答になる)。

ueno/ibus-skk の `src/engine.vala` は辞書 URI の `encoding=` を `new Skk.SkkServ(host, port, encoding)` へ渡す (`plist.get("encoding") ?? "EUC-JP"`)。そこで server エントリに `encoding=UTF-8` を明示すると UTF-8 通信に切り替わる。この設定を手動 `dconf write` ではなく `hosts/ubuntu.nix` の `dconf.settings` に宣言化した (再構築時に自動復元)。

```nix
"desktop/ibus/engine/skk" = {
  dictionaries = [
    "file=${config.home.homeDirectory}/.config/ibus-skk/user.dict,mode=readwrite,type=file"
    "host=127.0.0.1,port=1178,type=server,encoding=UTF-8"
  ];
};
```

反映は `home-manager switch` 後に `ibus restart`。以降 ibus-engine-skk が UTF-8 で yaskkserv2 に接続する。

## Test plan

- [x] `nix build '.#homeConfigurations."nanasess@ubuntu".activationPackage'` 成功
- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` 成功 (デグレ無し)
- [x] `nix flake check` 通過
- [x] `pkgs/yaskkserv2.nix` 単体ビルドで `yaskkserv2 --version` / `yaskkserv2_make_dictionary --help` 動作確認
- [x] 生成 service の `ExecStart` が Nix ストアバイナリ、辞書パスが両ホスト統一 (`~/.local/share/yaskkserv2/all`) を確認
- [x] **実機 (ubuntu)**: 辞書ビルド → `switch` → `systemctl --user status yaskkserv2` → python3 ソケットテストで「あい」変換確認
- [x] **実機 (ibus-skk)**: `dconf.settings` の `encoding=UTF-8` を `switch` で反映 → `ibus restart` → 漢字変換確認
- [x] **実機 (wsl-gentoo)**: 辞書を新パスへ再ビルド → `switch` → 同上（動作確認済み）

## 移行メモ

- コマンドは上記「セットアップ手順（ホスト別）」に集約。wsl-gentoo は辞書の再ビルドが 1 回必要。
- init.el のフォールバック（サーバ未起動時はユーザー辞書のみに縮退）により、移行途中でも Emacs は動作継続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * yaskkserv2 を Nix 経由で導入・管理できるようになりました。
  * WSL Gentoo / Ubuntu 共通の手順に対応しました。
  * ユーザーサービスとして起動・再起動しやすくなりました。

* **ドキュメント**
  * セットアップ手順を更新し、sudo やシステム側配置に依存しない流れへ整理しました。
  * 設定変更後の反映手順を見直しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


