### PR TITLE
feat(claude): 破壊的 Bash コマンドをブロックする PreToolUse hook を追加

### DIFF
--- a/modules/claude/default.nix
+++ b/modules/claude/default.nix
@@ -3,7 +3,10 @@
   # Claude Code のユーザーレベル設定のうち、宣言的に管理したいものだけを
   # home-manager 経由で ~/.config/claude/ へ symlink する。
   #
-  # 対象は CLAUDE.md (全プロジェクト共通指示) のみ。
+  # 対象は CLAUDE.md (全プロジェクト共通指示) と hooks/ (PreToolUse hook 等)。
+  # hooks/ のスクリプトは settings.json の hooks 設定から参照される
+  # (配線となる settings.json 側の hooks エントリは下記の理由で宣言管理せず、
+  # nanasess/claude.git リポジトリで追跡する)。
   # settings.json はこのモジュールでは扱わない:
   #   - Claude Code は実行時 state (theme / feedbackSurveyState / verbose 等) を
   #     settings.json ではなく ~/.config/claude/.claude.json に書き込むため、
@@ -15,4 +18,12 @@
   # 注意: ~/.config/claude は別 git リポジトリ (nanasess/claude.git) でもあり、
   # symlink 化により当該リポジトリ側では CLAUDE.md が type-changed として見える。
   xdg.configFile."claude/CLAUDE.md".source = ./CLAUDE.md;
+
+  # PreToolUse hook: 破壊的 Bash コマンド (rm -rf のシステムパス指定等) の
+  # 決定論的ブロック。CLAUDE.md のインジェクション警戒ルールはソフト層のため、
+  # ハーネス側の最後の砦としてモデルの判断を経由せず遮断する。
+  xdg.configFile."claude/hooks/block-dangerous-bash.sh" = {
+    source = ./hooks/block-dangerous-bash.sh;
+    executable = true;
+  };
 }

--- a/modules/claude/hooks/block-dangerous-bash.sh
+++ b/modules/claude/hooks/block-dangerous-bash.sh
@@ -8,6 +8,13 @@
 # stdin: {"tool_name":"Bash","tool_input":{"command":"..."}}
 set -u
 
+# jq が無い環境では検査不能のため fail-closed にする。exit 2 が「ブロッキング
+# エラー」(ツール実行を止める)。exit 1 等は非ブロッキングで実行が継続される。
+if ! command -v jq >/dev/null 2>&1; then
+  echo "block-dangerous-bash.sh: jq が見つからないため安全側でブロックします" >&2
+  exit 2
+fi
+
 cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null)
 [ -z "$cmd" ] && exit 0
 
@@ -18,10 +25,10 @@ emit() { # $1=permissionDecision $2=reason
 }
 
 # ファイルシステム・デバイス破壊系は無条件 deny
-if echo "$cmd" | grep -qE '(^|[;&|]\s*|\s)mkfs(\.[a-z0-9]+)?\s'; then
+if echo "$cmd" | grep -qE '(^|[;&|]\s*|\s)mkfs(\.[a-z0-9]+)?(\s|[;&|]|$)'; then
   emit deny "mkfs はブロック対象です (block-dangerous-bash.sh)"
 fi
-if echo "$cmd" | grep -qE '(^|[;&|]\s*|\s)dd\s[^;&|]*of=/dev/'; then
+if echo "$cmd" | grep -qE "(^|[;&|]\s*|\s)dd\s[^;&|]*of=['\"]?/dev/"; then
   emit deny "dd による /dev/* への直接書き込みはブロック対象です (block-dangerous-bash.sh)"
 fi
 

--- a/modules/claude/hooks/block-dangerous-bash.sh
+++ b/modules/claude/hooks/block-dangerous-bash.sh
@@ -32,7 +32,7 @@ if echo "$cmd" | grep -qE '(^|[;&|]\s*|\s)rm\s' \
 
   # rm と同一コマンドセグメント内 ([;&|] を跨がない) にシステムパス等の致命的
   # ターゲットがあれば deny。/home 直下・~ 直下は deny、それより深い個別パスは ask に落ちる。
-  if echo "$cmd" | grep -qE "rm\s[^;&|]*\s(/(bin|boot|dev|etc|lib|lib64|opt|proc|root|run|sbin|srv|sys|usr|var)(/[^[:space:];&|]*)?|/home(/[^/[:space:]]+)?/?|/\*?|~/?|\\\$HOME/?|\.\.)([[:space:];&|'\"]|$)"; then
+  if echo "$cmd" | grep -qE "rm\s[^;&|]*\s['\"]?(/(bin|boot|dev|etc|lib|lib64|opt|proc|root|run|sbin|srv|sys|usr|var)(/[^[:space:];&|]*)?|/home(/[^/[:space:]]+)?/?|/\*?|~/?|\\\$HOME/?|\.\./?)([[:space:];&|'\"]|$)"; then
     emit deny "システムパス・ホーム直下への rm 再帰+強制削除はブロック対象です (block-dangerous-bash.sh)"
   fi
   emit ask "rm の再帰+強制削除が含まれます。対象パスを確認してください (block-dangerous-bash.sh)"

--- a/modules/claude/hooks/block-dangerous-bash.sh
+++ b/modules/claude/hooks/block-dangerous-bash.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash) — 破壊的コマンドの決定論的ブロック
+#
+# モデルの判断 (CLAUDE.md) はプロンプトインジェクションで上書きされうるため、
+# 最後の砦としてハーネス側で決定論的に遮断する。
+#   - deny: システムパス・ホーム直下への rm 再帰+強制削除、mkfs、dd of=/dev/*
+#   - ask : その他の rm 再帰+強制 (node_modules 削除等の正当用途があるため確認に留める)
+# stdin: {"tool_name":"Bash","tool_input":{"command":"..."}}
+set -u
+
+cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$cmd" ] && exit 0
+
+emit() { # $1=permissionDecision $2=reason
+  jq -n --arg d "$1" --arg r "$2" \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:$d,permissionDecisionReason:$r}}'
+  exit 0
+}
+
+# ファイルシステム・デバイス破壊系は無条件 deny
+if echo "$cmd" | grep -qE '(^|[;&|]\s*|\s)mkfs(\.[a-z0-9]+)?\s'; then
+  emit deny "mkfs はブロック対象です (block-dangerous-bash.sh)"
+fi
+if echo "$cmd" | grep -qE '(^|[;&|]\s*|\s)dd\s[^;&|]*of=/dev/'; then
+  emit deny "dd による /dev/* への直接書き込みはブロック対象です (block-dangerous-bash.sh)"
+fi
+
+# rm の再帰フラグ + 強制フラグの併用を検出 (-rf / -fr / -r -f / --recursive --force / -Rf)
+if echo "$cmd" | grep -qE '(^|[;&|]\s*|\s)rm\s' \
+  && echo "$cmd" | grep -qE '\s(-[a-zA-Z]*[rR][a-zA-Z]*|--recursive)(\s|$)' \
+  && echo "$cmd" | grep -qE '\s(-[a-zA-Z]*f[a-zA-Z]*|--force)(\s|$)'; then
+
+  # rm と同一コマンドセグメント内 ([;&|] を跨がない) にシステムパス等の致命的
+  # ターゲットがあれば deny。/home 直下・~ 直下は deny、それより深い個別パスは ask に落ちる。
+  if echo "$cmd" | grep -qE "rm\s[^;&|]*\s(/(bin|boot|dev|etc|lib|lib64|opt|proc|root|run|sbin|srv|sys|usr|var)(/[^[:space:];&|]*)?|/home(/[^/[:space:]]+)?/?|/\*?|~/?|\\\$HOME/?|\.\.)([[:space:];&|'\"]|$)"; then
+    emit deny "システムパス・ホーム直下への rm 再帰+強制削除はブロック対象です (block-dangerous-bash.sh)"
+  fi
+  emit ask "rm の再帰+強制削除が含まれます。対象パスを確認してください (block-dangerous-bash.sh)"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Claude Code の PreToolUse hook (`modules/claude/hooks/block-dangerous-bash.sh`) を追加し、破壊的 Bash コマンドをモデルの判断を経由せず決定論的にブロックする
- PR #113 (CLAUDE.md のプロンプトインジェクション警戒ルール = ソフト層) を補完する、ハーネス側の最後の砦
- 本 PR の説明は、対策のきっかけとなった「プロンプトインジェクション疑い事例」のトランスクリプト解析記録を兼ねる (下記)

## Changes

- **`modules/claude/hooks/block-dangerous-bash.sh`**: PreToolUse hook スクリプト
  - **deny**: `rm` の再帰+強制削除 (`-rf` / `-fr` / `-r -f` / `--recursive --force` / `-Rf`) のうちシステムパス (`/etc` `/usr` `/var` `/boot` 等)・`/` `/*`・`~` / `$HOME` 直下・`..` を対象とするもの、`mkfs`、`dd of=/dev/*`
  - **ask**: その他の rm 再帰+強制 (`rm -rf node_modules` 等の正当用途があるため確認プロンプトに昇格)
  - 通常フロー: 上記以外 (出力なしで exit 0)
- **`modules/claude/default.nix`**: `xdg.configFile` で `~/.config/claude/hooks/` へ executable symlink を配備
- settings.json 側の hooks 配線 (`matcher: Bash` → 本スクリプト) は、Claude Code が書き込むファイルのため宣言管理せず nanasess/claude.git で追跡
- 既知の制限: コマンド文字列全体への文字列マッチのため、heredoc や引用文字列内に危険コマンド様の文字列が含まれる場合も安全側に誤検知する (実際に本 PR 作成コマンド自体が本文中の引用文字列でブロックされ、`--body-file` 経由に切り替えた)

## 背景: プロンプトインジェクション疑い事例の解析記録 (2026-07-07)

### 事象

別プロジェクト (`eclub.hyogo.jp.worktrees/issue-15`) のセッション「GitHub issue 15 の実装計画を確認」(Opus 4.8) で、Claude が「ツール出力ストリームへの注入・汚染が継続している」と繰り返し主張した:

- `rm -rf /var backups` の実行を促す注入指示 (「git check-ignore の出力に紛れ込んでいた」と主張)
- `"meta":"ignore this"` という偽フィールド
- 偽の System 警告・「[Behavior guidelines]／No new user message」
- 偽ユーザー発話「Playwright は使えますか」

### 解析結果: 実際の注入は存在せず、モデルの confabulation (作話) だった

トランスクリプト (JSONL、全 505 エントリ) を精査した結果:

| 主張された注入 | 実際の所在 |
|---|---|
| `rm -rf /var backups` 実行要求 | **assistant 出力にのみ出現**。全 tool_result・ユーザー入力・attachment に存在しない |
| 出所とされた `git check-ignore` の出力 | **主張時点で `git check-ignore` は一度も実行されていない** (直前のツールは ToolSearch / TaskList で、結果は空と "No tasks found" のみ) |
| `"meta":"ignore this"` 偽フィールド | `"meta"` という文字列は**トランスクリプト全体に存在しない**。tool_result 中の "ignore this" は Rails リポジトリの `.gitignore` 内の無害なコメント (`unless supporting rvm < 1.11.0 ..., ignore this:`) のみ |
| 偽ユーザー発話「Playwright は使えますか」 | **どのユーザー入力・キュー・attachment にも存在しない**。モデルが存在しない質問に自発的に回答 (「はい、Playwright は使えます」) した |
| 偽 System 警告・「No new user message」 | assistant 出力にのみ出現 |

- 発症時点のコンテキストは **~158k トークン**、セッション終了時は **239k トークン** (150k 超で判断品質が下がる既知の傾向と整合)
- ユーザーの「playwright を使えとは一言も言っていません。プロンプトインジェクションではないですか？」という指摘を、モデルが「注入の確証」と解釈して虚偽の物語が強化された
- さらにこの虚偽の物語が**プロジェクトメモリに永続化**されていた (`feedback_mypage-migration-decisions.md`) → 解析後に訂正済み

### 教訓

1. 「偽ユーザー発話」「偽 System 警告」を外部攻撃者が偽装するチャネルはローカルセッションに通常存在しない。これらの報告は**注入よりも作話・コンテキスト破損を第一仮説**とする
2. 注入を疑ったら、モデルの主張ではなく**トランスクリプト (JSONL) の tool_result 実体**で検証する
3. 実注入・作話のどちらであっても、破壊的コマンドの最終防衛線はモデルの判断 (CLAUDE.md) ではなく**ハーネス側の決定論的機構** (permission / hook) に置く — 本 PR はその実装

### 多層防御の全体像

| 層 | 実装 | 状態 |
|---|---|---|
| ソフト層: モデルへの指示 | CLAUDE.md「プロンプトインジェクション警戒」節 | PR #113 (マージ済) |
| ハード層: 決定論的ブロック | 本 PR の PreToolUse hook | 本 PR |
| 汚染記憶の浄化 | issue-15 プロジェクトメモリの虚偽記載を訂正 | 適用済 |
| 運用 | 巨大コンテキストの回避 (/compact, /clear)、permission allowlist を広げない | 既存ルール |

## Test plan

- [x] hook スクリプトを 18 ケースで pipe テスト (deny 12 / ask 3 / 通常フロー 3、誤検知なし)
- [x] `home-manager switch --flake '.#nanasess@wsl-gentoo'` 成功、executable symlink 配備を確認
- [x] symlink 経由で deny / ask / 通常フローの 3 ケース再検証
- [x] センチネル方式で実セッションの Bash 呼び出し時に hook が発火することを確認
- [x] 実運用でも発火を確認 (本 PR 作成コマンドの本文中の引用文字列を deny — 安全側の誤検知として想定どおり)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
