### PR TITLE
feat(zsh): worktree のタブ補完を .zshrc に追加

### DIFF
--- a/modules/zsh/default.nix
+++ b/modules/zsh/default.nix
@@ -146,7 +146,20 @@
 
         # git-worktree-manager シェル統合 (switch/create/checkout 後の自動 cd)
         # https://github.com/nanasess/git-worktree-manager/pull/24
-        if command -v worktree > /dev/null; then eval "$(worktree shell-init)"; fi
+        if command -v worktree > /dev/null; then
+          eval "$(worktree shell-init)"
+
+          # タブ補完 (サブコマンド / タスク名)。compinit 後に eval する必要がある。
+          # https://github.com/nanasess/git-worktree-manager/pull/32
+          #
+          # 成功時のみ eval する理由: completion 未対応バージョンでは
+          # "Unknown command" とヘルプ全文が *stdout* に出るため、
+          # eval "$(...)" 形式だと起動のたびにそれを実行しようとしてエラーが出る。
+          if _wt_completion=$(worktree completion zsh 2>/dev/null); then
+            eval "$_wt_completion"
+          fi
+          unset _wt_completion
+        fi
 
         # misc
         export BAT_THEME=ansi-light


### PR DESCRIPTION
## Summary

- [nanasess/git-worktree-manager#32](https://github.com/nanasess/git-worktree-manager/pull/32) で追加された `worktree completion zsh` を `modules/zsh/default.nix` に反映
- 既存の `worktree shell-init` 統合 (#24 由来) の隣に配置し、`worktree` 関連の設定を 1 ブロックにまとめた
- 補完非対応バージョンでもシェル起動時にエラーが出ないようガードを入れた

## Changes

`modules/zsh/default.nix` の 1 ファイルのみ。

PR #32 は zsh 補完を **compinit の後**に eval することを要求している。この要件は、当該ブロックが home-manager のデフォルト order (1000) にあり、`completionInit` の compinit より後に出力されることで満たしている (生成 `.zshrc` で compinit が 31 行目、補完 eval が 146 行目)。

### `eval "$(...)"` を直接使わなかった理由

`shell-init` と同じ `if command -v worktree; then eval "$(worktree completion zsh)"; fi` の形にはせず、終了ステータスで分岐している:

- `~/.local/bin/worktree` は `~/git-repos/git-worktree-manager/worktree` への symlink であり、**PR #32 はまだ未マージ**。チェックアウトを main に戻した瞬間、補完非対応版が呼ばれる
- `worktree` は未知のサブコマンドに対して `Unknown command` とヘルプ全文を **stderr ではなく stdout** に出力する (`usage()` / `log_error()` がいずれも `echo`)。そのため `2>/dev/null` では防げず、`eval` がヘルプテキストを実行しようとする
- 実測でシェル起動のたびに `(eval):1: bad pattern: ^[[0` が発生することを確認 (ANSI 色コードがパターンとして解釈される)

PR #32 がマージされ、全ホストのバージョンが揃った後もこのガードは無害なので、そのまま残す想定。

## Test plan

- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` → 成功 (exit 0)
- [x] 生成された `.zshrc` で compinit (31 行目) より後 (146 行目) に配置されることを確認
- [x] 実 zsh で PR #32 版を eval → `_comps[worktree]` = `_worktree`、`_worktree` 関数の定義を確認
- [x] main 版 (補完非対応) を一時 worktree に取得して eval → ガードにより無出力で正常終了することを確認。ガード無しでは `bad pattern` エラーが再現
- [x] `home-manager switch` による実適用は未実施

## Related

- 依存: [nanasess/git-worktree-manager#32](https://github.com/nanasess/git-worktree-manager/pull/32) (**未マージ**。マージまでは補完非対応版でガードが働く状態)
- 関連: [nanasess/git-worktree-manager#24](https://github.com/nanasess/git-worktree-manager/pull/24) (`shell-init` 統合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)