### PR TITLE
fix(ssh): ssh 先へ送る TERM を xterm-256color に降格

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -147,17 +147,15 @@
     includes = [
       "~/.ssh/conf.d/*.conf"
     ];
-    matchBlocks."*" = {
-      extraOptions = {
-        "IdentityAgent" = "~/.1password/agent.sock";
-        # Ghostty の TERM=xterm-ghostty をそのまま送ると、terminfo エントリを
-        # 持たないリモートで zsh/readline の行編集・履歴表示が崩れる。
-        # GhostInTheWSL は Windows 側から WSL の PTY に直結するため WSL 側で
-        # shell integration が有効にならず、Ghostty 公式の
-        # shell-integration-features = ssh-terminfo に頼れない。
-        # TERM は SetEnv の例外でリモート sshd の AcceptEnv 不要 (man ssh_config)。
-        "SetEnv" = "TERM=xterm-256color";
-      };
+    settings."*" = {
+      IdentityAgent = "~/.1password/agent.sock";
+      # Ghostty の TERM=xterm-ghostty をそのまま送ると、terminfo エントリを
+      # 持たないリモートで zsh/readline の行編集・履歴表示が崩れる。
+      # GhostInTheWSL は Windows 側から WSL の PTY に直結するため WSL 側で
+      # shell integration が有効にならず、Ghostty 公式の
+      # shell-integration-features = ssh-terminfo に頼れない。
+      # TERM は SetEnv の例外でリモート sshd の AcceptEnv 不要 (man ssh_config)。
+      SetEnv.TERM = "xterm-256color";
     };
   };
 

--- a/home.nix
+++ b/home.nix
@@ -150,6 +150,13 @@
     matchBlocks."*" = {
       extraOptions = {
         "IdentityAgent" = "~/.1password/agent.sock";
+        # Ghostty の TERM=xterm-ghostty をそのまま送ると、terminfo エントリを
+        # 持たないリモートで zsh/readline の行編集・履歴表示が崩れる。
+        # GhostInTheWSL は Windows 側から WSL の PTY に直結するため WSL 側で
+        # shell integration が有効にならず、Ghostty 公式の
+        # shell-integration-features = ssh-terminfo に頼れない。
+        # TERM は SetEnv の例外でリモート sshd の AcceptEnv 不要 (man ssh_config)。
+        "SetEnv" = "TERM=xterm-256color";
       };
     };
   };


### PR DESCRIPTION
## 概要

ssh で他ホストへ接続すると `TERM=xterm-ghostty` がそのまま伝播し、リモート側の shell 操作 (行編集・履歴表示) が乱れる問題を修正する。

## 原因

- リモートには `xterm-ghostty` の terminfo エントリが存在しないため、zsh/readline が terminfo の読み込みに失敗し、貧弱なフォールバックに落ちる。
- GhostInTheWSL は Windows 側から WSL の PTY へ直結するブリッジ構成のため、WSL 側で `GHOSTTY_RESOURCES_DIR` が設定されず shell integration が有効にならない。よって Ghostty 公式の `shell-integration-features = ssh-terminfo` に頼れない。

## 対処

`programs.ssh.matchBlocks."*".extraOptions` に `SetEnv TERM=xterm-256color` を追加する。

`TERM` は `SetEnv` の例外としてリモート sshd の `AcceptEnv` 設定が不要 (`man ssh_config` に明記)。`TERM` は env チャネルリクエストではなく `pty-req` で送られ、`SetEnv` がその値を上書きする (OpenSSH 8.7+ の挙動、手元は 10.3p1)。

### 代替案との比較

| 案 | 判断 |
|---|---|
| zsh 関数 `ssh() { TERM=xterm-256color command ssh "$@" }` | 不採用。TRAMP やスクリプト経由の ssh に効かず、コマンド shadowing の副作用もある |
| リモートへ terminfo を自動転送 (`infocmp -x \| ssh host tic -x -`) | 不採用。リモートに `tic` が必要で、無い場合は現状のまま崩れる。キャッシュ管理も複雑 |
| **ssh_config の `SetEnv`** | **採用**。リモート変更不要、全 ssh 経路をカバー、ホスト単位の出し分けも宣言的に可能 |

### 失われる capability

`xterm-ghostty` 固有の `Sync` (synchronized output)、`Smulx`/`Setulc` (undercurl・下線色)、`Tc`/`setrgbf`/`setrgbb`、`hs`/`tsl` (タイトル設定)、`fullkbd` (kitty keyboard protocol)、`ich1` 等は失われる。ただし terminfo が存在しないリモートでは元々一切利用できていないため、**現状より劣化する項目は無い**。

特定ホストで `xterm-ghostty` を維持したくなった場合は、`Host *` より前に個別の `matchBlocks` を置けば OpenSSH の先勝ちルールで上書きできる。

## 検証

- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` 成功
- [x] 生成された `~/.ssh/config` に `SetEnv TERM=xterm-256color` を確認
- [x] `home-manager switch` 適用後、`ssh -G example.invalid` が `setenv TERM=xterm-256color` を返すことを確認
- [x] **未検証**: 実際に ssh 先へ接続しての `echo $TERM` 確認。localhost の sshd は稼働しているが 1Password agent の鍵が `authorized_keys` に無く認証が通らなかったため。次回の実接続時に確認する

## 補足 (本 PR では未対応)

- `programs.ssh.matchBlocks` / `.extraOptions` が home-manager で deprecated になっており `programs.ssh.settings` への移行を促す warning が出ている (本変更以前からの既存警告)
- ローカルの `~/.terminfo/x/xterm-ghostty` が home-manager 管理外の手動配置のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * SSH接続時に、リモート環境へ`TERM=xterm-256color`を自動的に通知するようになりました。
  * GhosttyやWSL利用時の端末表示・シェル統合の互換性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->