### PR TITLE
feat(ghostty): xterm-ghostty の terminfo を宣言的に配置

### DIFF
--- a/modules/ghostty/default.nix
+++ b/modules/ghostty/default.nix
@@ -70,4 +70,20 @@ in
   _module.args.ghostty = {
     inherit settings configFile ghostinthewslConfigFile;
   };
+
+  # xterm-ghostty の terminfo を ~/.terminfo に配置する。
+  #
+  # wsl-gentoo は端末が Windows 側で動く (Ghostty Windows port / GhostInTheWSL) ため
+  # WSL 側に ghostty パッケージを入れておらず、TERM=xterm-ghostty だけが渡ってくる。
+  # terminfo が無いと zsh/readline が行編集・履歴表示を崩すので、terminfo だけを
+  # 独立 output (クロージャ 4.9 KiB、ghostty 本体を引き込まない) から供給する。
+  #
+  # 配置先を ~/.terminfo にする理由: ncurses は system 版 (Gentoo/Ubuntu の
+  # /usr/bin) と Nix 版のどちらも ~/.terminfo を無条件に検索するため、
+  # TERMINFO_DIRS の設定なしで確実に引ける。home.packages 経由だと
+  # ~/.nix-profile/share/terminfo が検索パスに入る保証がない (非 NixOS のため)。
+  #
+  # 別名 g/ghostty は張らない。Ghostty が渡す TERM は常に xterm-ghostty。
+  home.file.".terminfo/x/xterm-ghostty".source =
+    "${pkgs.ghostty.terminfo}/share/terminfo/x/xterm-ghostty";
 }


### PR DESCRIPTION
## 概要

`~/.terminfo/x/xterm-ghostty` が home-manager 管理外の手動配置のままだったため、宣言的に管理する。PR #117 (ssh の TERM 降格) の際に見つかった残件。

## 背景

`~/.terminfo/x/xterm-ghostty` は store へのシンボリックリンクではなく、書き込み可能な実体ファイル (`rw-r--r-- nanasess`) だった。以前 Nix の ghostty を入れた際に store からコピーされたものが残存していたと思われる。このままだと環境再構築時に失われ、ローカルの Ghostty で `xterm-ghostty` が解決できなくなる。

wsl-gentoo は端末が Windows 側で動く (Ghostty Windows port / GhostInTheWSL) ため WSL 側に ghostty パッケージを入れておらず、`TERM=xterm-ghostty` だけが渡ってくる。terminfo が無いと zsh/readline が行編集・履歴表示を崩す (リモートで起きていたのと同じ症状)。

## 対処

nixpkgs の ghostty が持つ `terminfo` 独立 output から供給する。バイナリをリポジトリにコミットする必要はない。

```nix
home.file.".terminfo/x/xterm-ghostty".source =
  "${pkgs.ghostty.terminfo}/share/terminfo/x/xterm-ghostty";
```

### 設計判断

| 判断 | 理由 |
|---|---|
| `home.packages` ではなく `home.file` で `~/.terminfo` へ | `~/.terminfo` は system 版 (Gentoo/Ubuntu の `/usr/bin`) と Nix 版のどちらの ncurses も無条件に検索する。非 NixOS では `~/.nix-profile/share/terminfo` が検索パスに入る保証がなく、`TERMINFO_DIRS` の設定が別途必要になる |
| `ghostty` 本体ではなく `terminfo` output を参照 | クロージャが 4.9 KiB で済み、ghostty 本体を引き込まない。`meta.outputsToInstall` は `[ "out" ]` なので `home.packages` に ghostty を足しても terminfo output は入らない |
| 別名 `g/ghostty` は張らない | Ghostty が渡す `TERM` は常に `xterm-ghostty` |
| `modules/ghostty/` に配置 | ghostty を使う wsl-gentoo と ubuntu の両方が import しており、macos は import していない |

## 検証

- [x] 移行前の手動配置ファイルと `ghostty.terminfo` の中身が `cmp` でバイト単位一致 (3854 bytes)。移行による内容変化なし
- [x] `nix build` が wsl-gentoo / ubuntu とも成功
- [x] `home-manager switch` 適用後、`~/.terminfo/x/xterm-ghostty` が store へのシンボリックリンクになることを確認
- [x] `infocmp xterm-ghostty` が解決可能
- [x] 主要 capability が読める: `Sync=\E[?2026...`, `Smulx=\E[4:%p1%dm`, `tput -T xterm-ghostty colors` = 256

### 補足

既存の手動配置ファイルは home-manager が上書きを拒否するため、`switch` 前に削除が必要だった (store 版とバイト一致を確認済みのため安全)。他ホストで同じ状態にある場合は同様の対応が要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)