### PR TITLE
feat: Markdown ビューア mo-viewer (k1LoW/mo) を全ホスト共通パッケージに追加

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -26,6 +26,9 @@
     ffmpeg
     whois
     pandoc
+    # k1LoW/mo — Markdown をブラウザで開くビューア。バイナリ名は `mo`。
+    # nixpkgs の `mo` は別物 (tests-always-included/mo, Bash 用 Moustache) なので混同しないこと。
+    mo-viewer
     poppler-utils
     lftp
     pigz


### PR DESCRIPTION
## Summary

- Markdown をブラウザで開くビューア [k1LoW/mo](https://github.com/k1LoW/mo) を `home.nix` の共通 `home.packages` に追加
- nixpkgs での attribute 名は `mo` ではなく **`mo-viewer`** (実行バイナリは `mo`)
- `nixpkgs#mo` は別物 (tests-always-included/mo, Bash 用 Moustache テンプレート) で、両方入れると `mo` コマンド名が衝突するため、混同防止のコメントをコードに併記

## Changes

`home.nix` の CLI tools セクション、`pandoc` の直後にドキュメント系 CLI として追加:

```nix
    pandoc
    # k1LoW/mo — Markdown をブラウザで開くビューア。バイナリ名は `mo`。
    # nixpkgs の `mo` は別物 (tests-always-included/mo, Bash 用 Moustache) なので混同しないこと。
    mo-viewer
    poppler-utils
```

パッケージ情報:

| 項目 | 値 |
|---|---|
| attribute 名 | `mo-viewer` |
| 実行バイナリ | `mo` (`meta.mainProgram`) |
| homepage | https://github.com/k1LoW/mo |
| license | MIT |
| バージョン | flake.lock 固定: **1.6.2** (nixpkgs 最新は 1.6.3) |
| `meta.platforms` | `x86_64-linux` / `aarch64-darwin` / `x86_64-darwin` を含む → 3 ホスト共通で可 |

主な機能: GitHub 風 Markdown レンダリング、シンタックスハイライト、Mermaid 図、LaTeX 数式、ファイル保存時のライブリロード、全文検索、MDX 対応。

## Test plan

- [x] `nix fmt` — `0 / 1 have been reformatted` (整形済み)
- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` — 成功 (exit=0)。`mo-viewer-1.6.2` を cache.nixos.org から取得できることを確認 (ローカルビルド不要)
- [x] `nix build '.#homeConfigurations."nanasess@ubuntu".activationPackage'` — 成功 (exit=0)
- [x] macbook (aarch64-darwin) — 当該環境ではビルド不可のため `drvPath` の eval のみ実施し成功。`meta.platforms` に darwin を含むことを別途確認
- [ ] CI (check / emacs / build マトリクス) のグリーン確認
- [ ] `home-manager switch` 後に `mo --version` / 実際の `.md` 表示を実機確認

## 補足

バージョンは flake.lock 固定の 1.6.2 です。1.6.3 に上げるには `nix flake update` が必要ですが、他の input も同時に動くため本 PR では実施していません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Markdownファイルをブラウザで閲覧できるCLIツール「mo-viewer」を追加しました。
  - コマンド名の混同を防ぐための注意事項を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->