### PR TITLE
fix(wsl-gentoo): BROWSER を存在しない wslview から wsl-open へ置き換え

### DIFF
--- a/hosts/wsl-gentoo.nix
+++ b/hosts/wsl-gentoo.nix
@@ -63,10 +63,18 @@ in
     emacs30-pgtk
     # 字形本体の Noto。home.nix 共通から移動 (Ubuntu のみ OS 静的 Noto に委譲する方針)。
     noto-fonts
+    # WSL から Windows 既定ブラウザを開く opener (内部で powershell.exe Start を呼ぶ)。
+    # BROWSER から参照する。portage の /usr/bin/wsl-open ではなく Nix で宣言して
+    # ホスト間の入手経路を揃える (CLAUDE.md「プラットフォーム非依存化の判断基準」)。
+    wsl-open
   ];
 
   home.sessionVariables = {
-    BROWSER = "wslview";
+    # 従来の wslview (wslu) は upstream が archive され nixpkgs からも削除済みで、
+    # 実体が無いまま参照だけが残っていた。BROWSER を argv[0] として spawn する
+    # 呼び出し側 (Claude Code の URL オープン等) では ENOENT で無反応になるため
+    # wsl-open へ置き換える。
+    BROWSER = "wsl-open";
   };
 
   # WezTerm 設定を Windows 側にコピー


### PR DESCRIPTION
## 概要

`hosts/wsl-gentoo.nix` の `BROWSER = "wslview"` が実体の無いコマンドを指しており、WSL から Windows のブラウザが起動できない状態だったのを修正する。

## 背景

- `wslview` は [wslu](https://github.com/wslutilities/wslu) 由来だが、upstream が archive されたため nixpkgs からも削除済み。

  ```console
  $ nix eval nixpkgs#wslu.pname
  error: 'wslu' has been removed because the project has been discontinued and the repository has been archived
  $ type -a wslview
  wslview not found
  ```

- `BROWSER` を argv[0] としてそのまま spawn する呼び出し側では ENOENT になり無反応になる。実例として Claude Code の URL オープン実装 (2.1.220) は下記のとおり `$BROWSER` を spawn し、`code===127 || ENOENT` を `opener_missing` として握り潰す。

  ```js
  let t = AS()?.browser, r = t !== undefined ? t ?? undefined : Z.BROWSER;
  return iay(await an(r || "xdg-open", [e]));
  ```

  Claude Code 2.1.181 で fullscreen モードの URL オープンが Ctrl+click 必須になった際に、この経路を踏んで発覚した。

## 変更内容

- `home.packages` に nixpkgs の `wsl-open` (2.2.1) を追加
- `BROWSER = "wsl-open"` へ変更

portage の `/usr/bin/wsl-open` にも同じものが入っているが、CLAUDE.md の「プラットフォーム非依存化の判断基準」に従い Nix で宣言する。

## 検証

- `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'` 成功
- 生成物に反映されていることを確認

  ```console
  $ rg -n BROWSER result/home-path/etc/profile.d/hm-session-vars.sh
  5:export BROWSER="wsl-open"
  $ ls -l result/home-path/bin/wsl-open
  ... -> /nix/store/zh5aykl8qqr917fnvsb939ym202qjisd-wsl-open-2.2.1/bin/wsl-open
  ```

- 起動コマンドの dry run

  ```console
  $ DryRun=true wsl-open 'https://example.com'
  wsl-open: RUN: /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe Start "https://example.com"
  ```

- `BROWSER=wsl-open claude` で起動し、GhostInTheWSL 上で Ctrl+click から Windows 既定ブラウザが開くことを実機確認済み

## 補足 (この PR の対象外)

Claude Code fullscreen モードではマウスレポート (`\e[?1000h`) が有効になるため、Ghostty 側のリンク hover 判定 (`src/Surface.zig` `cursorPosCallback`) が抑止され、**Ctrl+hover しても URL に下線が付かない**。これは端末側の仕様であり、Ctrl+click 自体は Claude Code に届いて動作する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * WSL環境で既定のブラウザを開けない問題を修正しました。
  * ブラウザ起動時に、Windows側の既定ブラウザが正しく開くようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->