### PR TITLE
feat(emacs): nskk まわりの調整 (C-j 挙動 / doom-modeline 表示 / pgtk+Wayland の IME 遮断)

### DIFF
--- a/modules/emacs/default.nix
+++ b/modules/emacs/default.nix
@@ -68,6 +68,11 @@ in
     cmigemo
   ];
 
+  # GTK_IM_MODULE は GTK の IM モジュール選択、XMODIFIERS は X11 の XIM 用。
+  # どちらも pgtk ビルド (ubuntu の emacs30-pgtk) + Wayland では効かない
+  # (GNOME Shell が text-input-v3 で直接繋ぐため)。そちらは init.el の
+  # my/pgtk-disable-im-context が pgtk-use-im-context で無効化している。
+  # ここの 2 行は X11 (WSLg / XWayland) 経由で起動した場合の保険として残す。
   home.file.".local/bin/emacs-wrapper" = lib.mkIf pkgs.stdenv.isLinux {
     executable = true;
     text = ''

--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -189,6 +189,30 @@
 ;; https://github.com/hamano/locale-eaw
 (load (expand-file-name (locate-user-emacs-file "site-lisp/eaw-console")) t t)
 
+;; Ubuntu (GNOME + Wayland) では ibus が常駐しており、入力ソースに ibus-skk が
+;; 選ばれた状態だと Emacs にプリエディットが送り込まれて nskk が使えなくなる。
+;; emacs-wrapper が設定する GTK_IM_MODULE / XMODIFIERS はそれぞれ GTK の IM モジュール
+;; 選択と X11 の XIM 用で、pgtk ビルド (emacs30-pgtk) + Wayland では GNOME Shell が
+;; text-input-v3 プロトコル経由で直接繋ぐため効かない。そこで Emacs 側で
+;; GtkIMContext 自体を切り、キーイベントを ibus を介さず直接受け取る。
+;; ibus の設定 (入力ソース一覧や ibus-skk の辞書設定) には手を入れないので、
+;; 他のアプリケーションでの ibus-skk の利用は従来どおり。
+;;
+;; `pgtk-use-im-context' はフレーム未作成の状態では "Frames are not in use or not
+;; initialized" で失敗する (early-init.el からは呼べない) ため、フレーム生成後の
+;; フックから呼ぶ。daemon 起動時は最初の emacsclient -c まで遅延する。
+(defun my/pgtk-disable-im-context (&optional frame)
+  "FRAME (既定は選択中のフレーム) の GtkIMContext を無効化する。
+pgtk フレーム以外 (X11 の `x' や tty の `t') では何もしないので、
+wsl-gentoo の非 pgtk 構成に読み込まれても無害。"
+  (let ((frame (or frame (selected-frame))))
+    (when (and (fboundp 'pgtk-use-im-context)
+               (eq (framep frame) 'pgtk))
+      (pgtk-use-im-context nil (frame-terminal frame)))))
+
+(add-hook 'window-setup-hook #'my/pgtk-disable-im-context)
+(add-hook 'after-make-frame-functions #'my/pgtk-disable-im-context)
+
 ;; nskk は upstream で *.el を src/ サブディレクトリに移動したため、
 ;; elpaca のデフォルト :files では nskk.el が見つからずビルドが失敗する。
 ;; src/*.el を明示的にビルド対象に加える。

--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -198,9 +198,31 @@
            :build (:not elpaca-build-autoloads))
   :demand t
   ;; ddskk の (global-set-key "\C-x\C-j" 'skk-mode) と等価。
-  ;; C-j はグローバルに束縛しない: nskk 無効時は素の改行に戻り、
-  ;; nskk 有効時は nskk-mode-map の C-j (#'nskk-kakutei) が確定/かな復帰/改行を担う。
-  :bind (("C-x C-j" . nskk-toggle-mode))
+  ;; C-j はグローバルに束縛しない: nskk 無効時は素の改行に戻る。
+  ;; nskk 有効時の C-j は nskk-mode-map で my/nskk-kakutei-or-latin に差し替える。
+  :preface
+  (defun my/nskk-kakutei-or-latin ()
+    "▽/▼ 変換中は確定し、■ひらがな待機中は ASCII モードへ切り替える。
+
+nskk 既定の `nskk-kakutei' は ■ひらがな待機中に改行を挿入する
+\(nskk.el の kakutei-action/2 fact: hiragana-idle -> insert-newline)。
+一方、旧 ddskk 環境では C-j がグローバルに `skk-mode' へ束縛されており
+\(dotfiles 39a2239 の init.el:166)、■かなモードの C-j は日本語入力の
+ON/OFF トグルとして働き改行しなかった。skk-j-mode-map には C-j が
+張られない (skk.el の `(when (vectorp skk-kakutei-key) ...)' ガード) ため
+グローバル束縛が優先されていたことによる。
+
+その指使いを nskk-mode 自体を落とさずに復元する。ASCII モードからの
+復帰は `nskk-kakutei' 既定の direct-idle -> enter-hiragana がそのまま
+担うので、C-j 一発で ■かな <-> ASCII を往復できる。▽/▼ 中の確定と
+ローマ字ペンディングの破棄も `nskk-kakutei' に委譲する。"
+    (interactive)
+    (if (eq (nskk--current-kakutei-state) 'hiragana-idle)
+        (nskk-set-mode-latin)
+      (nskk-kakutei)))
+  :bind (("C-x C-j" . nskk-toggle-mode)
+         :map nskk-mode-map
+         ("C-j" . my/nskk-kakutei-or-latin))
   :custom
   (nskk-dict-user-dictionary-file (concat external-directory "nskk/jisyo"))
   ;; ddskk の skk-mode 同様、有効化したら直接ひらがな入力に入る (既定は 'ascii)。
@@ -243,7 +265,17 @@
   ;; study (文脈学習) は nskk 本体が require しない。nskk--enable の
   ;; (featurep 'nskk-study) 判定で永続化対象に含めるため、初回有効化より前に
   ;; 明示 require する (learning-score のみなら不要)。
-  (require 'nskk-study nil t))
+  (require 'nskk-study nil t)
+  ;; nskk の入力モード表示は minor-mode lighter として実装されているが
+  ;; (nskk.el の `:lighter (:eval (nskk-modeline-indicator))')、doom-modeline は
+  ;; minor-mode lighter を描画しない (doom-modeline-minor-modes nil) ため
+  ;; 画面に出ない。lsp-bridge と同じ方針で mode-line-misc-info へ積み、
+  ;; doom-modeline の misc-info セグメント経由で描画させる。
+  ;; `nskk-mode' を条件に置いているので無効なバッファでは何も出ない。
+  ;; doom-modeline を切ると lighter と二重に出るが、常用構成では有効なため許容する。
+  (add-to-list 'mode-line-misc-info
+               '(nskk-mode (:eval (nskk-modeline-indicator)))
+               t))
 
 (elpaca-wait)
 


### PR DESCRIPTION
## Summary

nskk を実用するための調整 3 件。

- **C-j**: ■ひらがな待機中に改行が入っていたのを、旧 ddskk 環境と同じ「日本語入力の ON/OFF トグル」相当 (ASCII モードへの切替) に戻す
- **モードライン**: doom-modeline 使用時に nskk の入力モード (かな / カナ / SKK / 全英) が表示されない問題を修正
- **IME**: Ubuntu (GNOME + Wayland) で ibus-skk が選ばれていると Emacs で nskk が使えなくなる問題を修正

## Changes

### 1. C-j を `my/nskk-kakutei-or-latin` に差し替え

nskk 既定の `nskk-kakutei` は ■ひらがな待機中に改行を挿入する。

```elisp
;; nskk.el kakutei-action/2 fact
(hiragana-idle  insert-newline)
```

一方、旧 ddskk 環境では C-j が `skk-mode` (トグル) にグローバル束縛されており、改行しなかった。

```elisp
;; nanasess/dotfiles 39a2239 .emacs.d/init.el:166
(global-set-key (kbd "C-j") 'skk-mode)
```

`skk-j-mode-map` には C-j が張られない (skk.el の `(when (vectorp skk-kakutei-key) ...)` ガード。`skk-kakutei-key` の既定値は文字列 `"\C-j"` のためこの `define-key` は実行されない) ため、グローバル束縛が優先されていた。

`nskk-mode-map` の C-j を差し替えてこの指使いを復元する。`nskk-mode` 自体は落とさないので、`nskk-mode-map` が生き続けグローバル C-j (素の改行) を潰す必要もない。

| 状態 | 変更前 | 変更後 |
|---|---|---|
| ■ひらがな待機 | 改行が入る | ASCII モードへ |
| ASCII (SKK) | ひらがなへ | ひらがなへ (変更なし) |
| ▽ 見出し語入力中 | 確定 | 確定 (変更なし) |
| ▼ 変換中 | 確定 | 確定 (変更なし) |
| ローマ字ペンディング | 破棄 | 破棄 (変更なし) |

`C-x C-j` (`nskk-toggle-mode`) は据え置き。

### 2. 入力モード表示を `mode-line-misc-info` へ

nskk は minor-mode lighter で表示する。

```elisp
;; nskk.el:187
:lighter (:eval (nskk-modeline-indicator))
```

doom-modeline は `doom-modeline-minor-modes` が nil のため minor-mode lighter を描画せず、画面に出ない。lsp-bridge で既に採っている方針 (init.el の `my/lsp-bridge--mode-line-format` 参照) と同じく `mode-line-misc-info` に積み、doom-modeline の misc-info セグメント経由で描画させる。

### 3. pgtk + Wayland で GtkIMContext を無効化

Ubuntu (GNOME + Wayland) では ibus が常駐し、入力ソースに ibus-skk が選ばれた状態だと Emacs にプリエディットが送り込まれて nskk が使えなくなる。

`emacs-wrapper` が設定する `GTK_IM_MODULE` / `XMODIFIERS` はそれぞれ GTK の IM モジュール選択と X11 の XIM 用で、pgtk ビルド (`emacs30-pgtk`) + Wayland では GNOME Shell が text-input-v3 プロトコルで直接繋ぐため効かない。`pgtk-use-im-context` で GtkIMContext 自体を切り、キーイベントを ibus を介さず直接受け取る。

`pgtk-use-im-context` はフレーム未作成の状態では `"Frames are not in use or not initialized"` で失敗する (early-init.el や `--batch` からは呼べない) ため、`window-setup-hook` と `after-make-frame-functions` から呼ぶ。後者により daemon + `emacsclient -c` でも効く。`(framep frame)` が `pgtk` のときだけ実行するので、X11 (`x`) や tty (`t`) の wsl-gentoo 構成に読み込まれても無害。

ibus の設定 (入力ソース一覧、`hosts/ubuntu.nix` の ibus-skk 辞書設定) には手を入れていないため、他アプリケーションでの ibus-skk の利用は従来どおり。

## Test plan

- [x] `check-parens` による init.el の構文チェック
- [x] `nix build '.#homeConfigurations."nanasess@wsl-gentoo".activationPackage'`
- [x] `nix build '.#homeConfigurations."nanasess@ubuntu".activationPackage'`
- [x] C-j の状態遷移 (`emacs -Q --batch` に nskk をロードして検証)
  - ■ひらがな (`hiragana-idle`) → C-j → ASCII (`direct-idle`)
  - ASCII (`direct-idle`) → C-j → ■ひらがな (`hiragana-idle`)
  - 上記操作後のバッファ内容が `""` (改行が入らないこと)
- [x] モードライン表示 (Emacs daemon 上で `format-mode-line` を実評価。`--batch` では mode-line が常に空になるため daemon を使用)
  - 素の mode-line: `-UUU:--- F1  *t*  All L1  (Fundamental かな)  かな---`
  - doom-modeline: `  *t*  L1 All   かな LF UTF-8  Fundamental `
  - `doom-modeline-minor-modes` は nil のままなので doom-modeline 使用時に二重表示にならないこと
- [x] 実 GUI フレームでの `pgtk-use-im-context` 呼び出し: `(:framep pgtk :graphic t :call-noarg :ok :call-terminal :ok)`
- [x] 追加コードを実 GUI フレームで読み込み、`window-setup-hook` が最後まで到達すること (例外が出ないこと)
- [x] 実機 (WSL2 Gentoo, GUI Emacs) での C-j / モードライン表示の確認
- [x] 実機 (Ubuntu 24.04, GNOME Wayland) で ibus のエンジンが skk (ibus-skk) に選択されている状態でも、Emacs では nskk で問題なく入力できること

### 既知の制約

doom-modeline の misc-info セグメントは `(doom-modeline--segment-visible 'misc-info)` によりアクティブなモードラインでのみ描画される。非アクティブウィンドウにも表示したい場合は `doom-modeline-always-visible-segments` に `misc-info` を追加する。既存の lsp-bridge 表示も同じ制約下にあり、運用上は問題になっていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
