### PR TITLE
feat(emacs): mo (Markdown ビューア) 連携コマンドと WSL の browse-url 経路を追加

### DIFF
--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -483,6 +483,23 @@ ON/OFF トグルとして働き改行しなかった。skk-j-mode-map には C-j
   :custom
   (ediff-window-setup-function 'ediff-setup-windows-plain))
 
+(use-package browse-url
+  :ensure nil
+  :defer t
+  :config
+  ;; WSL では browse-url の既定経路 (browse-url-default-browser → xdg-open) が
+  ;; WSLg 上の Linux ブラウザを起動してしまい、Windows 側の既定ブラウザに渡らない。
+  ;; xdg-open は DE を検出できた場合 $BROWSER を見ずに .desktop 側へ振るため。
+  ;; そこで BROWSER が指すコマンド (wsl-gentoo.nix では wsl-open) を
+  ;; browse-url から直接叩く。BROWSER 未設定のホスト (ubuntu 等) では既定のまま。
+  ;; BROWSER は XDG 仕様上 ":" 区切りのリストになり得るので xdg-open と同じく
+  ;; 順に試し、実体のあるものを採る (wslview が消えていた事例があるため
+  ;; executable-find は必須)。どれも無ければ既定経路にフォールバックする。
+  (when-let* ((program (seq-some #'executable-find
+                                 (split-string (or (getenv "BROWSER") "") ":" t))))
+    (setopt browse-url-browser-function #'browse-url-generic
+            browse-url-generic-program program)))
+
 ;;;; ============================================================
 ;;;; Theme & UI
 ;;;; ============================================================
@@ -929,8 +946,134 @@ ON/OFF トグルとして働き改行しなかった。skk-j-mode-map には C-j
   :custom
   (markdown-fontify-code-blocks-natively t)
   (markdown-indent-on-enter 'indent-and-new-item)
+  ;; C-c C-c o (markdown-open) を mo 連携に差し替える。関数を指定した場合
+  ;; markdown-open は save-buffer を呼ばないため、保存は my/mo-open 側で行う。
+  (markdown-open-command #'my/mo-open)
   :bind (:map markdown-mode-map
-         ("<S-tab>" . markdown-shifttab)))
+         ("<S-tab>" . markdown-shifttab)
+         ("C-c C-v" . my/mo-open)))
+
+;;;; ------------------------------------------------------------
+;;;; mo (k1LoW/mo) — Markdown をブラウザで表示するローカルサーバ
+;;;; ------------------------------------------------------------
+;; home.nix の mo-viewer で導入 (バイナリ名は `mo`)。既定ポート 6275 に単一
+;; サーバが常駐し、以降の `mo FILE` は同じセッションへファイルを追加していく。
+;;
+;; mo 側の性質と、それに合わせた設計方針:
+;;   - 開いたファイルは fsnotify で監視され、保存するたびにブラウザが自動再描画
+;;     される。よって Emacs 側に「プレビュー再生成」の仕組みは不要で、
+;;     一度開いた後は普通に C-x C-s するだけでよい。
+;;   - --json は「そのファイル専用の URL」(…/?file=<hash>) を返す。ブラウザ起動を
+;;     mo 任せにするとグループ先頭が開かれるだけなので、--no-open で抑止して
+;;     URL を受け取り、Emacs の browse-url で対象ファイルへ直接ジャンプさせる。
+;;   - --target でタブグループを分けられるので、project ルート名を割り当てる。
+;;   - 標準入力からも読めるため、ファイルを訪問していないバッファやリージョンの
+;;     一時プレビューに使える (ただし実ファイルが無いのでライブリロードは効かない)。
+;;
+;; --json 指定時、JSON は stdout に出て進捗メッセージは stderr に分離される。
+;; サーバ未起動でも mo は自身をデーモン化して即座に返るため call-process で問題ない。
+
+(defvar my/mo-program "mo"
+  "mo (k1LoW/mo) の実行ファイル名。")
+
+(defvar my/mo-use-project-target t
+  "非 nil なら project のルート名を mo の --target グループ名として使う。")
+
+(defun my/mo--target-args ()
+  "現在の project 名を --target 引数のリストとして返す。project 外なら nil。"
+  (when my/mo-use-project-target
+    (when-let* ((project (project-current))
+                (root (project-root project)))
+      (list "--target" (file-name-nondirectory (directory-file-name root))))))
+
+(defun my/mo--call (args &optional input)
+  "mo を ARGS で実行し、標準出力を文字列で返す。
+INPUT が非 nil なら、その文字列を mo の標準入力へ渡す。
+リージョンではなく文字列を受け取るのは、`with-temp-buffer' の内側では
+`call-process-region' の領域指定が一時バッファ基準になってしまうため。"
+  (unless (executable-find my/mo-program)
+    (user-error "mo が PATH にありません (home.nix の mo-viewer を参照)"))
+  (with-temp-buffer
+    ;; DESTINATION を (BUFFER nil) にして stderr の進捗メッセージを捨てる。
+    (let ((status (if input
+                      ;; START が文字列の場合 END は無視される。
+                      (apply #'call-process-region input nil my/mo-program
+                             nil (list t nil) nil args)
+                    (apply #'call-process my/mo-program
+                           nil (list t nil) nil args))))
+      (unless (eq status 0)
+        (user-error "mo が exit code %s で失敗しました" status))
+      (buffer-string))))
+
+(defun my/mo--browse (output &optional group-only)
+  "mo --json の OUTPUT から URL を取り出し `browse-url' で開く。
+GROUP-ONLY が非 nil なら ?file=… を落としてグループの一覧を開く。"
+  (let* ((json (json-parse-string output :object-type 'alist :array-type 'list))
+         (url (or (alist-get 'url (car (alist-get 'files json)))
+                  (alist-get 'url json))))
+    (unless url
+      (user-error "mo の JSON 出力から URL を取得できませんでした"))
+    (when group-only
+      (setq url (replace-regexp-in-string "\\?file=.*\\'" "" url)))
+    (browse-url url)
+    (message "mo: %s" url)))
+
+(defun my/mo-send-region (start end)
+  "START..END (リージョン未選択ならバッファ全体) を標準入力で mo に渡して開く。
+実ファイルではないためライブリロードは効かない。一時的なプレビュー用。"
+  (interactive (if (use-region-p)
+                   (list (region-beginning) (region-end))
+                 (list (point-min) (point-max))))
+  (my/mo--browse
+   (my/mo--call (append '("--json" "--no-open") (my/mo--target-args))
+                (buffer-substring-no-properties start end))))
+
+(defun my/mo-open ()
+  "現在のバッファの Markdown を mo で開く。
+ファイルを訪問していればそれを保存してから mo に渡すので、以降は保存するだけで
+ブラウザ側が追従する。ファイル未訪問またはリージョン選択中は
+`my/mo-send-region' にフォールバックする。"
+  (interactive)
+  (if (or (use-region-p) (not buffer-file-name))
+      (call-interactively #'my/mo-send-region)
+    (when (buffer-modified-p)
+      (save-buffer))
+    (my/mo--browse
+     (my/mo--call (append '("--json" "--no-open")
+                          (my/mo--target-args)
+                          (list (expand-file-name buffer-file-name)))))))
+
+(defun my/mo-close ()
+  "現在のファイルを mo のセッションから外す。"
+  (interactive)
+  (unless buffer-file-name
+    (user-error "ファイルを訪問していないバッファです"))
+  (my/mo--call (append '("--close")
+                       (my/mo--target-args)
+                       (list (expand-file-name buffer-file-name))))
+  (message "mo: closed %s" (file-name-nondirectory buffer-file-name)))
+
+(defun my/mo-watch-project ()
+  "project 配下の Markdown を再帰的に mo の監視対象に加え、一覧を開く。
+--watch なので、以後そのツリーに追加された .md も自動でセッションに入る。"
+  (interactive)
+  (let ((root (project-root (project-current t))))
+    (my/mo--browse
+     (my/mo--call (append '("--json" "--no-open" "--watch" "--recursive")
+                          (my/mo--target-args)
+                          (list (expand-file-name root))))
+     t)))
+
+(defun my/mo-status ()
+  "起動中の mo サーバの一覧を表示する。"
+  (interactive)
+  (message "%s" (string-trim (my/mo--call '("--status")))))
+
+(defun my/mo-shutdown ()
+  "mo サーバを停止する。セッションは保存され、次回起動時に復元される。"
+  (interactive)
+  (my/mo--call '("--shutdown"))
+  (message "mo: shutdown"))
 
 (use-package polymode
   :ensure (:host github :repo "polymode/polymode")

--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -1049,23 +1049,41 @@ JSON からはグループを特定できないため。"
 (defun my/mo-open ()
   "現在のバッファの Markdown を mo で開く。
 ファイルを訪問していればそれを保存してから mo に渡すので、以降は保存するだけで
-ブラウザ側が追従する。ファイル未訪問またはリージョン選択中は
-`my/mo-send-region' にフォールバックする。"
+ブラウザ側が追従する。
+
+以下の場合は `my/mo-send-region' (標準入力) にフォールバックする。
+この経路では mo 側に実ファイルが無いためライブリロードは効かない。
+  - ファイルを訪問していないバッファ
+  - リージョン選択中
+  - TRAMP 越しのリモートファイル。mo はローカルプロセスなので
+    /ssh:host:/path/file.md をそのまま渡しても file not found で失敗する
+    (consult-tramp を使うため実際に起こりうる)。"
   (interactive)
-  (if (or (use-region-p) (not buffer-file-name))
-      (call-interactively #'my/mo-send-region)
+  (cond
+   ((or (use-region-p) (not buffer-file-name))
+    (call-interactively #'my/mo-send-region))
+   ((file-remote-p buffer-file-name)
+    (my/mo-send-region (point-min) (point-max))
+    ;; my/mo--browse の URL 表示を上書きしてでも、劣化していることを伝える。
+    (message "mo: リモートファイルのため内容のみ送信しました (ライブリロード不可)"))
+   (t
     (when (buffer-modified-p)
       (save-buffer))
     (my/mo--browse
      (my/mo--call (append '("--json" "--no-open")
                           (my/mo--target-args)
-                          (list (expand-file-name buffer-file-name)))))))
+                          (list (expand-file-name buffer-file-name))))))))
 
 (defun my/mo-close ()
   "現在のファイルを mo のセッションから外す。"
   (interactive)
   (unless buffer-file-name
     (user-error "ファイルを訪問していないバッファです"))
+  ;; リモートファイルはそもそもパスで mo に登録されない (my/mo-open が標準入力
+  ;; へ回す)。渡しても mo 側は該当なしで終わるのに closed と報告してしまうため、
+  ;; ここで弾く。
+  (when (file-remote-p buffer-file-name)
+    (user-error "リモートファイルは mo のセッションに入っていません"))
   (my/mo--call (append '("--close")
                        (my/mo--target-args)
                        (list (expand-file-name buffer-file-name))))
@@ -1082,6 +1100,11 @@ JSON からはグループを特定できないため。"
   (let* ((project (project-current t))
          (root (project-root project))
          (target-args (my/mo--target-args project)))
+    ;; mo はローカルプロセスなのでリモート root は監視できない。渡しても
+    ;; file not found で exit 1 になり、stderr を捨てている都合で理由の
+    ;; 分からないエラーになるため、ここで明示的に弾く。
+    (when (file-remote-p root)
+      (user-error "リモート project (%s) は mo で監視できません" root))
     (my/mo--browse
      (my/mo--call (append '("--json" "--no-open" "--watch" "--recursive")
                           target-args

--- a/modules/emacs/init.el
+++ b/modules/emacs/init.el
@@ -979,11 +979,24 @@ ON/OFF トグルとして働き改行しなかった。skk-j-mode-map には C-j
 (defvar my/mo-use-project-target t
   "非 nil なら project のルート名を mo の --target グループ名として使う。")
 
-(defun my/mo--target-args ()
-  "現在の project 名を --target 引数のリストとして返す。project 外なら nil。"
+(defun my/mo--target-args (&optional project)
+  "PROJECT (省略時は現在の project) 名を --target 引数のリストとして返す。
+project 外なら nil。
+
+PROJECT を受け取れるようにしてあるのは、`my/mo-watch-project' が
+`project-current' にプロンプトを許して取得した instance を、ここでも
+使い回す必要があるため。引き直すと元バッファの `default-directory'
+基準になり、監視対象とグループがずれる。
+
+グループ名に root の basename を使うのは、--target が mo の URL パス
+\(http://localhost:6275/<target>) とサイドバーのラベルにそのまま出るため。
+同名 root (例: ~/work/docs と ~/archive/docs) は同じグループに混ざるが、
+一意性より可読性を優先した意図的なトレードオフ。ハッシュや UUID に
+置き換えないこと。グループ分け自体が不要なら
+`my/mo-use-project-target' を nil にする。"
   (when my/mo-use-project-target
-    (when-let* ((project (project-current))
-                (root (project-root project)))
+    (when-let* ((current (or project (project-current)))
+                (root (project-root current)))
       (list "--target" (file-name-nondirectory (directory-file-name root))))))
 
 (defun my/mo--call (args &optional input)
@@ -1005,16 +1018,21 @@ INPUT が非 nil なら、その文字列を mo の標準入力へ渡す。
         (user-error "mo が exit code %s で失敗しました" status))
       (buffer-string))))
 
-(defun my/mo--browse (output &optional group-only)
+(defun my/mo--browse (output &optional group)
   "mo --json の OUTPUT から URL を取り出し `browse-url' で開く。
-GROUP-ONLY が非 nil なら ?file=… を落としてグループの一覧を開く。"
+既定ではファイル個別の URL (…/?file=<hash>) を開く。
+GROUP が非 nil なら、代わりにそのグループの一覧 (…/<group>) を開く。
+
+グループ URL を JSON から作らずベース URL と GROUP から組み立てるのは、
+既に登録済みのファイル・パターンを再登録したときに mo が files:[] を返し、
+JSON からはグループを特定できないため。"
   (let* ((json (json-parse-string output :object-type 'alist :array-type 'list))
-         (url (or (alist-get 'url (car (alist-get 'files json)))
-                  (alist-get 'url json))))
-    (unless url
+         (base (alist-get 'url json))
+         (url (if group
+                  (concat base "/" group)
+                (or (alist-get 'url (car (alist-get 'files json))) base))))
+    (unless base
       (user-error "mo の JSON 出力から URL を取得できませんでした"))
-    (when group-only
-      (setq url (replace-regexp-in-string "\\?file=.*\\'" "" url)))
     (browse-url url)
     (message "mo: %s" url)))
 
@@ -1057,12 +1075,18 @@ GROUP-ONLY が非 nil なら ?file=… を落としてグループの一覧を�
   "project 配下の Markdown を再帰的に mo の監視対象に加え、一覧を開く。
 --watch なので、以後そのツリーに追加された .md も自動でセッションに入る。"
   (interactive)
-  (let ((root (project-root (project-current t))))
+  ;; project-current に t を渡すと project 外のバッファでもプロンプトで選べる。
+  ;; その instance を my/mo--target-args にも渡すこと。渡さないと --target 側
+  ;; だけ元バッファの default-directory で引き直されて nil になり、監視対象は
+  ;; 選んだ root なのにグループは mo 既定の default という食い違いが起きる。
+  (let* ((project (project-current t))
+         (root (project-root project))
+         (target-args (my/mo--target-args project)))
     (my/mo--browse
      (my/mo--call (append '("--json" "--no-open" "--watch" "--recursive")
-                          (my/mo--target-args)
+                          target-args
                           (list (expand-file-name root))))
-     t)))
+     (cadr target-args))))
 
 (defun my/mo-status ()
   "起動中の mo サーバの一覧を表示する。"


### PR DESCRIPTION
## Summary

PR #121 で導入した [k1LoW/mo](https://github.com/k1LoW/mo) (`mo-viewer`) を Emacs から使えるようにする。あわせて WSL で `browse-url` が Windows 側ブラウザに届かない問題を修正。

## mo 連携

mo は既定ポート 6275 に単一サーバが常駐し、開いたファイルを fsnotify で監視して**保存のたびにブラウザを自動再描画する**。そのため Emacs 側に「プレビュー再生成」の仕組みは不要で、一度開いた後は普通に `C-x C-s` するだけでよい。

| コマンド | 動作 |
|---|---|
| `my/mo-open` | 現在のバッファを保存して mo で開く。ファイル未訪問・リージョン選択中は `my/mo-send-region` へフォールバック |
| `my/mo-send-region` | リージョン (未選択ならバッファ全体) を標準入力で渡す。実ファイルが無いためライブリロードは効かない |
| `my/mo-close` | 現在のファイルをセッションから外す |
| `my/mo-watch-project` | project 配下の `**/*.md` を `--watch --recursive` で監視。以後追加された `.md` も自動でセッション入り |
| `my/mo-status` / `my/mo-shutdown` | サーバの状態表示 / 停止 |

設計上のポイント:

- **`--json` + `--no-open`** — `--json` は「そのファイル専用の URL」(`…/?file=<hash>`) を返す。ブラウザ起動を mo 任せにするとグループ先頭が開かれるだけなので、`--no-open` で抑止して `browse-url` で対象ファイルへ直接ジャンプさせる
- **`--target` グループ** — project ルート名を割り当て、プロジェクトごとにタブグループを分離
- **`markdown-open-command`** — markdown-mode には既に「外部ビューアで開く」フック `markdown-open` (`C-c C-c o`) があるのでそこに接続。`M-x` 不要で開ける (別途 `C-c C-v` も割当、markdown-mode 既存バインドとの衝突なしを確認)

## browse-url の WSL 対応

`M-x my/mo-open` で **WSLg 上の Linux Chrome が起動し、Windows 側の既定ブラウザに渡らなかった**。

原因は既定経路 `browse-url-default-browser` → `browse-url-xdg-open` → `xdg-open`。`xdg-open` は **DE を検出できると `$BROWSER` を見ずに `.desktop` 経由で振る** (`$BROWSER` を見るのは DE 不明時の `open_generic` パスのみ)。

そこで `$BROWSER` が指すコマンドを `browse-url-generic` で直接叩き、xdg-open を経由しないようにした。ホスト分岐は書かず `$BROWSER` に委ねているので、`hosts/wsl-gentoo.nix` の `BROWSER = "wsl-open"` がそのまま効き、ubuntu (未設定) は既定のまま。`executable-find` のガードは、以前 `BROWSER` が実体のない `wslview` を指していた事例 (PR #123) の再発防止。

この変更は magit の `v` (PR を開く) など **`browse-url` を使う全機能**に効く。

## Test plan

- [x] `check-parens` — init.el 全体 OK
- [x] mo コマンド群の機能テスト 8 件 (バッチ Emacs、`browse-url` をスタブ、テスト用ポート 6276 に隔離) — 全通過
  - ファイルを開く / 未保存→自動保存 (`modified-p=nil`) / stdin フォールバック / リージョン送信 / `watch-project` (`watching: …/proj/**/*.md` 登録確認) / `status` / `close` / mo 不在時のエラー
- [x] `browse-url` の `$BROWSER` 分岐をバッチ Emacs で実測

  | BROWSER | `browse-url-browser-function` | `browse-url-generic-program` |
  |---|---|---|
  | `wsl-open` (wsl-gentoo) | `browse-url-generic` | `…/bin/wsl-open` |
  | 未設定 (ubuntu) | `browse-url-default-browser` | nil |
  | `wslview` (実体なし) | `browse-url-default-browser` (フォールバック) | nil |
  | `wslview:wsl-open` | `browse-url-generic` | `…/bin/wsl-open` (xdg-open 同様に順に試す) |
  | `wslview:does-not-exist` | `browse-url-default-browser` | nil |

- [x] `wsl-open -x 'http://localhost:6275/?file=abc123'` (dry-run) → `powershell.exe Start "http://…"`。URL がパス変換されず Windows 側へ渡ることを確認
- [x] `nix build` wsl-gentoo / ubuntu — ともに exit=0
- [x] `nix fmt` — 差分なし (変更は `init.el` のみ)
- [x] **実機確認** — `home-manager switch` 後、`M-x my/mo-open` で Windows 側の既定ブラウザが開き Markdown が表示されることを確認済み
- [ ] CI (check / emacs / build マトリクス) のグリーン確認

## 補足

実装中に 1 件バグを検出・修正した。`with-temp-buffer` の内側では `call-process-region` の START/END が一時バッファ基準になり、リージョン送信が `args-out-of-range` で落ちる。START が文字列なら END が無視される仕様を使い、文字列を渡す形に変更している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `BROWSER` 環境変数に指定したコマンドでURLを開けるようになりました。利用できない場合は従来の方法に戻ります。
  * Markdownからローカルプレビューサーバーを利用できるようになりました。
  * ファイルや選択範囲、プロジェクトの監視、状態確認、終了、シャットダウンに対応しました。
* **改善**
  * プレビュー対象のURLを自動取得し、取得に失敗した場合はエラーを通知します。
  * リモートファイルやリモートプロジェクトでは、適切な代替手段またはエラー通知に切り替わります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->